### PR TITLE
Optimizations on browserstack tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3494,6 +3494,61 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.44.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+          "dev": true
+        }
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7588,7 +7643,8 @@
           "dependencies": {
             "acorn": {
               "version": "6.3.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+              "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
               "dev": true
             }
           }
@@ -8472,6 +8528,12 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "chai": "^4.2.0",
     "chai-spies": "^1.0.0",
     "codecov": "^3.7.0",
+    "compression": "^1.7.4",
     "core-js": "^3.6.5",
     "cors": "^2.8.5",
     "eslint": "^7.0.0",

--- a/test-config/wdio.browserstack.conf.js
+++ b/test-config/wdio.browserstack.conf.js
@@ -2,9 +2,9 @@ const currentTime = Date.now()
 const commonCapabilities = {
   project: 'LiveConnect',
   build: `${process.env.CIRCLE_BRANCH || process.env.DEV_BRANCH || 'X'}-${process.env.CIRCLE_BUILD_NUM || currentTime}`,
-  'browserstack.video': true,
+  'browserstack.video': false,
   'browserstack.console': 'verbose',
-  'browserstack.debug': true,
+  'browserstack.debug': false,
   'browserstack.networkLogs': true,
   'browserstack.appium_version': '1.14.0'
 }
@@ -114,7 +114,7 @@ exports.config = {
   baseUrl: 'http://localhost',
   //
   // Default timeout for all waitFor* commands.
-  waitforTimeout: 60000,
+  waitforTimeout: 5,
   //
   // Default timeout in milliseconds for request
   // if Selenium Grid doesn't send response

--- a/test-config/wdio.browserstack.conf.js
+++ b/test-config/wdio.browserstack.conf.js
@@ -6,7 +6,7 @@ const commonCapabilities = {
   'browserstack.console': 'verbose',
   'browserstack.debug': false,
   'browserstack.networkLogs': true,
-  'browserstack.appium_version': '1.14.0'
+  'browserstack.appium_version': '1.17.1'
 }
 
 const allCapabilities = [

--- a/test-config/wdio.browserstack.conf.js
+++ b/test-config/wdio.browserstack.conf.js
@@ -2,11 +2,11 @@ const currentTime = Date.now()
 const commonCapabilities = {
   project: 'LiveConnect',
   build: `${process.env.CIRCLE_BRANCH || process.env.DEV_BRANCH || 'X'}-${process.env.CIRCLE_BUILD_NUM || currentTime}`,
-  'browserstack.video': false,
+  'browserstack.video': true,
   'browserstack.console': 'verbose',
-  'browserstack.debug': false,
+  'browserstack.debug': true,
   'browserstack.networkLogs': true,
-  'browserstack.appium_version': '1.17.1'
+  'browserstack.appium_version': '1.14.0'
 }
 
 const allCapabilities = [
@@ -114,7 +114,7 @@ exports.config = {
   baseUrl: 'http://localhost',
   //
   // Default timeout for all waitFor* commands.
-  waitforTimeout: 5,
+  waitforTimeout: 60000,
   //
   // Default timeout in milliseconds for request
   // if Selenium Grid doesn't send response

--- a/test/it/helpers/browser.js
+++ b/test/it/helpers/browser.js
@@ -1,4 +1,4 @@
-const WAIT_UNTIL_TIMEOUT_MILLIS = 1000
+const WAIT_UNTIL_TIMEOUT_MILLIS = 500
 const WAIT_UNTIL_INTERVAL = 15
 
 export function sendEvent (event, expectedRequests, server) {
@@ -7,7 +7,7 @@ export function sendEvent (event, expectedRequests, server) {
     browser.execute(`window.liQ = window.liQ || [];window.liQ.push(${json})`)
     browser.waitUntil(() => {
       return server.getHistory().length === expectedRequests
-    }, WAIT_UNTIL_TIMEOUT_MILLIS, "sendEvent timed out", WAIT_UNTIL_INTERVAL)
+    }, WAIT_UNTIL_TIMEOUT_MILLIS, `sendEvent timed out`, WAIT_UNTIL_INTERVAL)
   } catch (e) {
     console.error(e, server.getHistory().length, expectedRequests)
   }

--- a/test/it/helpers/browser.js
+++ b/test/it/helpers/browser.js
@@ -1,10 +1,13 @@
+const WAIT_UNTIL_TIMEOUT = 15000
+
+
 export function sendEvent (event, expectedRequests, server) {
   const json = JSON.stringify(event)
   try {
     browser.execute(`window.liQ = window.liQ || [];window.liQ.push(${json})`)
     browser.waitUntil(() => {
       return server.getHistory().length === expectedRequests
-    }, 5000)
+    }, WAIT_UNTIL_TIMEOUT)
   } catch (e) {
     console.error(e)
   }
@@ -15,7 +18,7 @@ export function resolveIdentity (expectedRequests, server) {
     browser.execute('window.liQ = window.liQ || [];window.liQ.resolve(function(response) { document.getElementById("idex").innerHTML = JSON.stringify(response); })')
     browser.waitUntil(() => {
       return server.getIdexHistory().length === expectedRequests
-    }, 5000)
+    }, WAIT_UNTIL_TIMEOUT)
   } catch (e) {
     console.error(e)
   }
@@ -26,7 +29,7 @@ export function fetchResolvedIdentity () {
     browser.waitUntil(() => {
       console.log($('#idex').getText())
       return $('#idex').getText() !== 'None'
-    }, 4000)
+    }, WAIT_UNTIL_TIMEOUT)
     return $('#idex').getText()
   } catch (e) {
     console.error('Error', e)

--- a/test/it/helpers/browser.js
+++ b/test/it/helpers/browser.js
@@ -7,7 +7,7 @@ export function sendEvent (event, expectedRequests, server) {
     browser.execute(`window.liQ = window.liQ || [];window.liQ.push(${json})`)
     browser.waitUntil(() => {
       return server.getHistory().length === expectedRequests
-    }, WAIT_UNTIL_TIMEOUT_MILLIS, `sendEvent timed out`, WAIT_UNTIL_INTERVAL)
+    }, WAIT_UNTIL_TIMEOUT_MILLIS, "sendEvent timed out", WAIT_UNTIL_INTERVAL)
   } catch (e) {
     console.error(e, server.getHistory().length, expectedRequests)
   }

--- a/test/it/helpers/browser.js
+++ b/test/it/helpers/browser.js
@@ -1,5 +1,5 @@
-const WAIT_UNTIL_TIMEOUT = 15000
-
+const WAIT_UNTIL_TIMEOUT_MILLIS = 1000
+const WAIT_UNTIL_INTERVAL = 15
 
 export function sendEvent (event, expectedRequests, server) {
   const json = JSON.stringify(event)
@@ -7,9 +7,9 @@ export function sendEvent (event, expectedRequests, server) {
     browser.execute(`window.liQ = window.liQ || [];window.liQ.push(${json})`)
     browser.waitUntil(() => {
       return server.getHistory().length === expectedRequests
-    }, WAIT_UNTIL_TIMEOUT)
+    }, WAIT_UNTIL_TIMEOUT_MILLIS, "sendEvent timed out", WAIT_UNTIL_INTERVAL)
   } catch (e) {
-    console.error(e)
+    console.error(e, server.getHistory().length, expectedRequests)
   }
 }
 
@@ -18,9 +18,9 @@ export function resolveIdentity (expectedRequests, server) {
     browser.execute('window.liQ = window.liQ || [];window.liQ.resolve(function(response) { document.getElementById("idex").innerHTML = JSON.stringify(response); })')
     browser.waitUntil(() => {
       return server.getIdexHistory().length === expectedRequests
-    }, WAIT_UNTIL_TIMEOUT)
+    }, WAIT_UNTIL_TIMEOUT_MILLIS, "resolveIdentity timed out", WAIT_UNTIL_INTERVAL)
   } catch (e) {
-    console.error(e)
+    console.error(e, server.getHistory().length, expectedRequests)
   }
 }
 
@@ -29,7 +29,7 @@ export function fetchResolvedIdentity () {
     browser.waitUntil(() => {
       console.log($('#idex').getText())
       return $('#idex').getText() !== 'None'
-    }, WAIT_UNTIL_TIMEOUT)
+    }, WAIT_UNTIL_TIMEOUT_MILLIS, "fetchResolvedIdentity timed out", WAIT_UNTIL_INTERVAL)
     return $('#idex').getText()
   } catch (e) {
     console.error('Error', e)
@@ -42,7 +42,7 @@ export function sendEventInIframe (event, expectedRequests, server) {
     switchToIFrame($('#iframe-id')) || switchToIFrame('iframe-name')
     sendEvent(event, expectedRequests, server)
   } catch (e) {
-    console.error(e)
+    console.error(e, server.getHistory().length, expectedRequests)
   }
 }
 

--- a/test/it/helpers/mock-server.js
+++ b/test/it/helpers/mock-server.js
@@ -12,8 +12,11 @@ const port = 3001
 
 const compression = require('compression')
 
+const bundle = fs.readFileSync('dist/bundle.iife.js', 'utf8')
+
 export function MockServerFactory (config) {
   const preamble = `window.LI=${JSON.stringify(config)};\n`
+  const fullContent =  preamble + bundle
   const app = express()
   app.use(compression())
   let history = []
@@ -59,7 +62,7 @@ export function MockServerFactory (config) {
   app.get('/tracker.js', (req, res) => {
     fs.readFile('dist/bundle.iife.js', 'utf8', (error, data) => {
       if (error) throw error
-      res.send(preamble + data)
+      res.send(fullContent)
       console.log('Returned data')
     })
   })

--- a/test/it/helpers/mock-server.js
+++ b/test/it/helpers/mock-server.js
@@ -10,9 +10,12 @@ const corsOptions = {
 }
 const port = 3001
 
+const compression = require('compression')
+
 export function MockServerFactory (config) {
   const preamble = `window.LI=${JSON.stringify(config)};\n`
   const app = express()
+  app.use(compression())
   let history = []
   let idex = []
   app.get('/page', (req, res) => {

--- a/test/it/helpers/mock-server.js
+++ b/test/it/helpers/mock-server.js
@@ -60,11 +60,8 @@ export function MockServerFactory (config) {
   })
 
   app.get('/tracker.js', (req, res) => {
-    fs.readFile('dist/bundle.iife.js', 'utf8', (error, data) => {
-      if (error) throw error
-      res.send(fullContent)
-      console.log('Returned data')
-    })
+    res.send(fullContent)
+    console.log('Returned data')
   })
 
   app.get('/p', (req, res) => {

--- a/test/it/live-connect.spec.js
+++ b/test/it/live-connect.spec.js
@@ -13,6 +13,7 @@ const packageJson = require('../../package')
 const COOKIE_TO_SCRAPE_NAME = 'cookie_to_scrape'
 
 describe('LiveConnect', () => {
+  this.retries(4)
   let server
 
   before(() => {

--- a/test/it/live-connect.spec.js
+++ b/test/it/live-connect.spec.js
@@ -12,11 +12,11 @@ import {
 const packageJson = require('../../package')
 const COOKIE_TO_SCRAPE_NAME = 'cookie_to_scrape'
 
-describe('LiveConnect', () => {
+describe('LiveConnect', function () {
   this.retries(4)
   let server
 
-  before(() => {
+  before(function () {
     server = serverUtil.MockServerFactory({
       collectorUrl: 'http://bln.test.liveintent.com:3001',
       identifiersToResolve: [COOKIE_TO_SCRAPE_NAME],
@@ -37,11 +37,11 @@ describe('LiveConnect', () => {
     console.log('\x1b[35m\x1b[4m%s\x1b[0m', `##### Finishing the test: '${this.currentTest.fullTitle()}'`)
   })
 
-  after(() => {
+  after(function () {
     server.stop()
   })
 
-  it('should send decisionIds', () => {
+  it('should send decisionIds', function () {
     const decisionIdOne = '4ca76883-1e26-3fb8-b6d1-f881ac7d6699'
     const decisionIdTwo = '5ca76883-1e26-3fb8-b6d1-f881ac7d6699'
     const supportsLS = probeLS()
@@ -58,7 +58,7 @@ describe('LiveConnect', () => {
     expect(`${decisionIdTwo},${decisionIdOne}`).to.eq(secondTrackingRequest['query']['li_did'])
   })
 
-  it('should send and receive results of IdentityResolution', () => {
+  it('should send and receive results of IdentityResolution', function () {
     server.openPage('bln.test.liveintent.com', 'page')
     resolveIdentity(1, server)
     const idexRequests = server.getIdexHistory()
@@ -67,7 +67,7 @@ describe('LiveConnect', () => {
     expect(idexValue).to.eq(JSON.stringify({ unifiedId: 'some-id' }))
   })
 
-  it('should send http request to pixel endpoint, and reuse cookies across subdomains', () => {
+  it('should send http request to pixel endpoint, and reuse cookies across subdomains', function () {
     server.openPage('bln.test.liveintent.com', 'page?li_did=something')
     const supportsLS = probeLS()
     const expectedRequests = supportsLS ? 1 : 2
@@ -100,7 +100,7 @@ describe('LiveConnect', () => {
     }
   })
 
-  it('should send http request to pixel endpoint with scraped cookies and hashes', () => {
+  it('should send http request to pixel endpoint with scraped cookies and hashes', function () {
     const cookie = {
       name: COOKIE_TO_SCRAPE_NAME,
       value: 'sample@liveintent.com'
@@ -130,7 +130,7 @@ describe('LiveConnect', () => {
     }
   })
 
-  it('should prepend duid cookie with hashed apex domain', () => {
+  it('should prepend duid cookie with hashed apex domain', function () {
     server.openPage('bln.test.liveintent.com', 'framed')
     sendEventInIframe({}, 1, server)
 


### PR DESCRIPTION
This PR:
- loads the bundle only once. There's no need to load the rollup bundle from FS every time the tracker is requested
- GZIPs the bundle, to potentially reduce the over the wire transfer between CCI & BS
- introduces retries
- splits the waitUntil into much smaller chunks, speeding up tests, as for cases where `expectedRequests` doesn't match the `server.getHistory().length` doesn't always wait for 4 seconds, but also allows more frequent checks on the condition.

Result: BS tests are down from ~20 mins to ~ 10.