### PR TITLE
RTA-119. Removed the redundant option to provide one's own FPC

### DIFF
--- a/COLLECTOR_PARAMS.md
+++ b/COLLECTOR_PARAMS.md
@@ -8,10 +8,6 @@
 - contains the LiveConnect managed first party identifier, in the `${apexDomainHash}--${ULID}`, or `${iframeDomainHash}-${websiteUrlDomainHash}--${ULID}` format
 ### `lduid`
 - contains the legacy LiveConnect first party identifier
-### `pfpi`
-- contains the value of the provided first party identifier (e.g the cookie found for key = `config.providedIdentifierName`)
-### `fpn`
-- contains the name passed as the key of the provided first party identifier, specifically the value of the `config.providedIdentifierName`
 ### `tna`
 - contains the `config.trackerName`
 ### `pu`

--- a/CONFIGURATION_OPTIONS.md
+++ b/CONFIGURATION_OPTIONS.md
@@ -38,15 +38,6 @@ There's also an option for the module to never create any first party identifier
 ```
 By setting this flag, LiveConnect will never write anything into any storage, but will still attempt to read from it.
 
-#### `providedIdentifierName` [Optional]
-This parameter defines the name of an identifier that can be found in local storage or in the cookie jar that can be sent along with the request.
-This parameter should be used whenever a customer is able to provide the most stable identifier possible, e.g. a cookie which is set via HttpHeaders on the first party domain.
-
-```javascript
-{
-  providedIdentifierName:"pubcid"
-}
-```
 #### `collectorUrl` [Optional, HasDefault]
 The parameter defines where the signal pixels are pointing to. The params and paths will be defined subsequently.
 If the parameter is not set, LiveConnect will by default emit the signal towards `https://rp.liadm.com`.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ It's sometimes important in which order the managers are invoked, as one might d
 `managers/decision.js` is responsible for keeping state in the browser with all the recent `li_did` parameters picked up from urls where LiveConnect was loaded.
 
 ### Identifiers manager
-`managers/identifiers.js` takes care of LiveConnect first party identifiers being created (if not present) and picked up so that they can be sent as signal pixels, or if the customers set the `providedIdentifierName`, that this information is also relayed to the pipeline.
+`managers/identifiers.js` takes care of LiveConnect first party identifiers being created (if not present) and picked up so that they can be sent as signal pixels containing that information.
 Where the LiveConnect identifiers are stored (Cookie vs LocalStorage) depends on the `config.storageStrategy` option.
 How long those identifiers will live is configured in the `config.expirationDays` parameter. In case the `storageStrategy` is set to Cookie, the browser will ensure that the cookie expires.
 In case of localStorage, Identifiers Manager and it's underlying `utils/storage.js` helper will ensure that on the next load, the entry is removed from localstorage in case it's obsolete.

--- a/esm/live-connect.js
+++ b/esm/live-connect.js
@@ -833,16 +833,6 @@ var _pMap = {
       return encodeURIComponent(s);
     });
   },
-  providedIdentifier: function providedIdentifier(pfpi) {
-    return _asParamOrEmpty('pfpi', pfpi, function (s) {
-      return encodeURIComponent(s);
-    });
-  },
-  providedIdentifierName: function providedIdentifierName(fpn) {
-    return _asParamOrEmpty('fpn', fpn, function (s) {
-      return encodeURIComponent(s);
-    });
-  },
   trackerName: function trackerName(tn) {
     return _asParamOrEmpty('tna', tn || 'unknown', function (s) {
       return encodeURIComponent(s);
@@ -1359,12 +1349,6 @@ function resolve(state, storageHandler) {
 
     var expiry = state.expirationDays || DEFAULT_EXPIRATION_DAYS;
     var cookieDomain = determineTld();
-    var providedFirstPartyIdentifier = null;
-
-    if (state.providedIdentifierName) {
-      providedFirstPartyIdentifier = storageHandler.getCookie(state.providedIdentifierName) || storageHandler.getDataFromLocalStorage(state.providedIdentifierName);
-    }
-
     var storageOptions = {
       expires: expiry,
       domain: cookieDomain
@@ -1372,8 +1356,7 @@ function resolve(state, storageHandler) {
     var liveConnectIdentifier = getOrAddWithExpiration(NEXT_GEN_FP_NAME, generateCookie(cookieDomain), storageOptions, state.storageStrategy);
     return {
       domain: cookieDomain,
-      liveConnectId: liveConnectIdentifier,
-      providedIdentifier: providedFirstPartyIdentifier
+      liveConnectId: liveConnectIdentifier
     };
   } catch (e) {
     error('IdentifiersResolve', 'Error while managing identifiers', e);
@@ -2022,7 +2005,6 @@ function IdentityResolver(config, storageHandler) {
     var tuples = [];
     tuples.push(['duid', encodedOrNull(nonNullConfig.peopleVerifiedId)]);
     tuples.push(['us_privacy', encodedOrNull(nonNullConfig.usPrivacyString)]);
-    tuples.push([encodedOrNull(nonNullConfig.providedIdentifierName), encodedOrNull(nonNullConfig.providedIdentifier)]);
     externalIds.forEach(function (retrievedIdentifier) {
       var key = encodedOrNull(retrievedIdentifier.name);
       var value = encodedOrNull(retrievedIdentifier.value);
@@ -2379,13 +2361,21 @@ function _pushSingleEvent(event, pixelClient, enrichedState) {
  *
  * @param {LiveConnectConfiguration} previousConfig
  * @param {LiveConnectConfiguration} newConfig
- * @return {boolean}
+ * @return {Object|null}
  * @private
  */
 
 
 function _configMatcher(previousConfig, newConfig) {
-  return previousConfig.appId === newConfig.appId && previousConfig.wrapperName === newConfig.wrapperName && previousConfig.collectorUrl === newConfig.collectorUrl;
+  var equalConfigs = previousConfig.appId === newConfig.appId && previousConfig.wrapperName === newConfig.wrapperName && previousConfig.collectorUrl === newConfig.collectorUrl;
+
+  if (!equalConfigs) {
+    return {
+      appId: [previousConfig.appId, newConfig.appId],
+      wrapperName: [previousConfig.wrapperName, newConfig.wrapperName],
+      collectorUrl: [previousConfig.collectorUrl, newConfig.collectorUrl]
+    };
+  }
 }
 
 function _processArgs(args, pixelClient, enrichedState) {
@@ -2416,13 +2406,13 @@ function _processArgs(args, pixelClient, enrichedState) {
 function _getInitializedLiveConnect(liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (window.liQ.config && !_configMatcher(window.liQ.config, liveConnectConfig)) {
-        var previousConfig = JSON.stringify(window.liQ.config);
-        var newConfig = JSON.stringify(liveConnectConfig);
+      var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
+
+      if (mismatchedConfig) {
         var error$1 = new Error();
         error$1.name = 'ConfigSent';
         error$1.message = 'Additional configuration received';
-        error('LCDuplication', "".concat(newConfig, "::").concat(previousConfig), error$1);
+        error('LCDuplication', JSON.stringify(mismatchedConfig), error$1);
       }
 
       return window.liQ;

--- a/src/idex/identity-resolver.js
+++ b/src/idex/identity-resolver.js
@@ -74,7 +74,6 @@ export function IdentityResolver (config, storageHandler) {
     const tuples = []
     tuples.push(['duid', encodedOrNull(nonNullConfig.peopleVerifiedId)])
     tuples.push(['us_privacy', encodedOrNull(nonNullConfig.usPrivacyString)])
-    tuples.push([encodedOrNull(nonNullConfig.providedIdentifierName), encodedOrNull(nonNullConfig.providedIdentifier)])
     externalIds.forEach(retrievedIdentifier => {
       const key = encodedOrNull(retrievedIdentifier.name)
       const value = encodedOrNull(retrievedIdentifier.value)

--- a/src/live-connect.js
+++ b/src/live-connect.js
@@ -22,7 +22,6 @@
  * @typedef {Object} LiveConnectConfiguration
  * @property {(string|undefined)} appId
  * @property {(StorageStrategy|null)} storageStrategy
- * @property {(string|undefined)} providedIdentifierName
  * @property {(string|undefined)} collectorUrl
  * @property {(string|undefined)} usPrivacyString
  * @property {(number|undefined)} expirationDays

--- a/src/live-connect.js
+++ b/src/live-connect.js
@@ -64,13 +64,20 @@ function _pushSingleEvent (event, pixelClient, enrichedState) {
  *
  * @param {LiveConnectConfiguration} previousConfig
  * @param {LiveConnectConfiguration} newConfig
- * @return {boolean}
+ * @return {Object|null}
  * @private
  */
 function _configMatcher (previousConfig, newConfig) {
-  return previousConfig.appId === newConfig.appId &&
+  const equalConfigs = previousConfig.appId === newConfig.appId &&
     previousConfig.wrapperName === newConfig.wrapperName &&
     previousConfig.collectorUrl === newConfig.collectorUrl
+  if (!equalConfigs) {
+    return {
+      appId: [previousConfig.appId, newConfig.appId],
+      wrapperName: [previousConfig.wrapperName, newConfig.wrapperName],
+      collectorUrl: [previousConfig.collectorUrl, newConfig.collectorUrl]
+    }
+  }
 }
 
 function _processArgs (args, pixelClient, enrichedState) {
@@ -98,13 +105,12 @@ function _processArgs (args, pixelClient, enrichedState) {
 function _getInitializedLiveConnect (liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (window.liQ.config && !_configMatcher(window.liQ.config, liveConnectConfig)) {
-        const previousConfig = JSON.stringify(window.liQ.config)
-        const newConfig = JSON.stringify(liveConnectConfig)
+      const mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig)
+      if (mismatchedConfig) {
         const error = new Error()
         error.name = 'ConfigSent'
         error.message = 'Additional configuration received'
-        emitter.error('LCDuplication', `${newConfig}::${previousConfig}`, error)
+        emitter.error('LCDuplication', JSON.stringify(mismatchedConfig), error)
       }
       return window.liQ
     }

--- a/src/manager/identifiers.js
+++ b/src/manager/identifiers.js
@@ -98,11 +98,6 @@ export function resolve (state, storageHandler) {
 
     const expiry = state.expirationDays || DEFAULT_EXPIRATION_DAYS
     const cookieDomain = determineTld()
-    let providedFirstPartyIdentifier = null
-    if (state.providedIdentifierName) {
-      providedFirstPartyIdentifier = storageHandler.getCookie(state.providedIdentifierName) ||
-        storageHandler.getDataFromLocalStorage(state.providedIdentifierName)
-    }
     const storageOptions = {
       expires: expiry,
       domain: cookieDomain
@@ -114,8 +109,7 @@ export function resolve (state, storageHandler) {
       state.storageStrategy)
     return {
       domain: cookieDomain,
-      liveConnectId: liveConnectIdentifier,
-      providedIdentifier: providedFirstPartyIdentifier
+      liveConnectId: liveConnectIdentifier
     }
   } catch (e) {
     emitter.error('IdentifiersResolve', 'Error while managing identifiers', e)

--- a/src/pixel/state.js
+++ b/src/pixel/state.js
@@ -13,8 +13,6 @@
  * @property {(string|null)} [appId]
  * @property {(object|undefined)} [eventSource]
  * @property {(string|undefined)} [liveConnectId]
- * @property {(string|undefined)} [providedIdentifier]
- * @property {(string|undefined)} [providedIdentifierName]
  * @property {(string|undefined)} [trackerName]
  * @property {(string|undefined)} [pageUrl]
  * @property {(string|undefined)} [domain]
@@ -23,7 +21,7 @@
  * @property {(string|undefined)} [wrapperName]
  * @property {(HashedEmail[])} [hashesFromIdentifiers]
  * @property {(string[]|undefined)} [identifiersToResolve]
- * @property {[]string} [decisionIds]
+ * @property {string[]} [decisionIds]
  * @property {string | undefined} [peopleVerifiedId]
  * @property {(string|undefined)} [storageStrategy]
  * @property {LegacyId} [legacyId]
@@ -81,12 +79,6 @@ const _pMap = {
   },
   legacyId: legacyFpc => {
     return _asParamOrEmpty('lduid', legacyFpc && legacyFpc.duid, (s) => encodeURIComponent(s))
-  },
-  providedIdentifier: pfpi => {
-    return _asParamOrEmpty('pfpi', pfpi, (s) => encodeURIComponent(s))
-  },
-  providedIdentifierName: fpn => {
-    return _asParamOrEmpty('fpn', fpn, (s) => encodeURIComponent(s))
   },
   trackerName: tn => {
     return _asParamOrEmpty('tna', tn || 'unknown', (s) => encodeURIComponent(s))

--- a/test/unit/manager/identifiers.spec.js
+++ b/test/unit/manager/identifiers.spec.js
@@ -52,18 +52,6 @@ describe('IdentifiersManager', () => {
     expect(resolutionResult.liveConnectId).to.eql(id)
   })
 
-  it('should read provided first party identifier from a cookie first', function () {
-    storage.setCookie('pfpcn', 'cookie-identifier')
-    const resolutionResult = identifiers.resolve({ providedIdentifierName: 'pfpcn' }, storage)
-    expect(resolutionResult.providedIdentifier).to.eql('cookie-identifier')
-  })
-
-  it('should read provided first party identifier from ls, if it cannot be found in a cookie', function () {
-    storage.setDataInLocalStorage('pfpcn', 'ls-identifier')
-    const resolutionResult = identifiers.resolve({ providedIdentifierName: 'pfpcn' }, storage)
-    expect(resolutionResult.providedIdentifier).to.eql('ls-identifier')
-  })
-
   it('should ignore a malformed legacy id', function () {
     expect(storage.getCookie('_lc2_fpi')).to.eql(null)
     storage.setDataInLocalStorage('_litra_id.2a0b', 'some-mumbo-jumbo')

--- a/test/unit/pixel/state.spec.js
+++ b/test/unit/pixel/state.spec.js
@@ -66,17 +66,6 @@ describe('EventComposition', () => {
     assert.includeDeepMembers(event.asTuples(), [['aid', '9898'], ['se', b64EncodedEventSource], ['lduid', legacyDuid]])
   })
 
-  it('should send the pfpi', function () {
-    const legacyDuid = 'a-0z68--e4f71227-70d0-4e54-b1c3-ACf80616bbb0'
-    const pixelData = {
-      providedIdentifier: legacyDuid,
-      providedIdentifierName: 'someName'
-    }
-    const event = new StateWrapper(pixelData)
-    expect(event.asQueryString()).to.eql(`?pfpi=${legacyDuid}&fpn=someName`)
-    assert.includeDeepMembers(event.asTuples(), [['pfpi', legacyDuid], ['fpn', 'someName']])
-  })
-
   it('should send the tracker name', function () {
     const trackerName = 'some-name'
     const pixelData = {


### PR DESCRIPTION
As the feature is already covered by `identifiersToResolve` we can safely remove the provided FPC params from config and stop reading those.