### PR TITLE
Add the --disable-gpu option

### DIFF
--- a/test-config/wdio.docker.chrome.conf.js
+++ b/test-config/wdio.docker.chrome.conf.js
@@ -50,7 +50,7 @@ exports.config = {
   //
   capabilities: [{
     browserName: 'chrome',
-    chromeOptions: {
+    'goog:chromeOptions': {
       args: ['--disable-gpu']
     }
   }],

--- a/test-config/wdio.docker.chrome.conf.js
+++ b/test-config/wdio.docker.chrome.conf.js
@@ -49,7 +49,10 @@ exports.config = {
   // https://docs.saucelabs.com/reference/platforms-configurator
   //
   capabilities: [{
-    browserName: 'chrome'
+    browserName: 'chrome',
+    chromeOptions: {
+      args: ['--disable-gpu']
+    }
   }],
   //
   // ===================
@@ -100,7 +103,7 @@ exports.config = {
   // commands. Instead, they hook themselves up into the test process.
   services: ['docker'],
   dockerOptions: {
-    image: 'selenium/standalone-chrome:3.141.59-20210713',
+    image: 'selenium/standalone-chrome:3.141.59',
     healthCheck: 'http://bln.test.liveintent.com:4444',
     options: {
       p: ['4444:4444'],

--- a/test-config/wdio.docker.chrome.conf.js
+++ b/test-config/wdio.docker.chrome.conf.js
@@ -100,7 +100,7 @@ exports.config = {
   // commands. Instead, they hook themselves up into the test process.
   services: ['docker'],
   dockerOptions: {
-    image: 'selenium/standalone-chrome:3.141.59',
+    image: 'selenium/standalone-chrome:91.0',
     healthCheck: 'http://bln.test.liveintent.com:4444',
     options: {
       p: ['4444:4444'],

--- a/test-config/wdio.docker.chrome.conf.js
+++ b/test-config/wdio.docker.chrome.conf.js
@@ -100,7 +100,7 @@ exports.config = {
   // commands. Instead, they hook themselves up into the test process.
   services: ['docker'],
   dockerOptions: {
-    image: 'selenium/standalone-chrome:91.0',
+    image: 'selenium/standalone-chrome:3.141.59-20210713',
     healthCheck: 'http://bln.test.liveintent.com:4444',
     options: {
       p: ['4444:4444'],


### PR DESCRIPTION
Going from this [version](https://hub.docker.com/layers/selenium/standalone-chrome/3.141.59-20210713/images/sha256-bc4023992691ab8e2f20297f334fdcddd982928fbd969239b39b3dbc2dfc0657?context=explore) to this [version](https://hub.docker.com/layers/selenium/standalone-chrome/3.141.59-20210729/images/sha256-9943ba9d2a89e984080f5681b390229fb47f7d3bb732e4f440456fc52335bae8?context=explore) of standalone Chrome our tests broke. The reason and solution are described here: https://github.com/SeleniumHQ/docker-selenium/issues/1346. 

AFAICS, we may leave the option there forever, as it does not influence our tests.

Author Todo List:

- [x] Add/adjust tests (if applicable)
- [x] Build in CI passes
- [x] Latest master revision is merged into the branch
- [x] Self-Review
- [x] Set `Ready For Review` status
