### PR TITLE
allow node version less than 16 as it is not supported by wdio

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "private": false,
   "name": "live-connect-js",
   "engines": {
-    "node": ">=8"
+    "node": ">=8 <16.0.0"
   },
   "scripts": {
     "test:unit": "npm run lint && nyc mocha --config test-config/mocha.unit.json --require @babel/register ",


### PR DESCRIPTION
Short description if any.
As per [webdriverio](https://webdriver.io/docs/sync-vs-async#:~:text=As%20of%2014/04/2021%20sync%20mode%20will%20not%20be%20supported%20anymore%20starting%20from%20Node.js%20v16%20due%20to) the sync is not supporting node16. 

Author Todo List:

- [x] Add/adjust tests (if applicable)
- [x] Build in CI passes
- [x] Latest master revision is merged into the branch
- [x] Self-Review
- [x] Set `Ready For Review` status
