### PR TITLE
RESEARCH - Supporting Multiple LiveConnect Initializations On The Same Page

### DIFF
--- a/cjs/initializer.js
+++ b/cjs/initializer.js
@@ -887,8 +887,8 @@ function _pixelError(error) {
 }
 function register(state, callHandler) {
   try {
-    if (window && window[EVENT_BUS_NAMESPACE] && isFunction(window[EVENT_BUS_NAMESPACE].on)) {
-      window[EVENT_BUS_NAMESPACE].on(ERRORS_PREFIX, _pixelError);
+    if (window && window[EVENT_BUS_NAMESPACE] && window[EVENT_BUS_NAMESPACE].current && isFunction(window[EVENT_BUS_NAMESPACE].current.on)) {
+      window[EVENT_BUS_NAMESPACE].current.on(ERRORS_PREFIX, _pixelError);
     }
     _pixelSender = new PixelSender(state, callHandler);
     _state = state || {};
@@ -1365,7 +1365,7 @@ function _processArgs(args, pixelClient, enrichedState, configManager) {
 function _getInitializedLiveConnect(liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (!qualifiedConfig(liveConnectConfig)) {
+      if (qualifiedConfig(window.liQ.config) || !qualifiedConfig(liveConnectConfig)) {
         var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
         if (mismatchedConfig) {
           var error$1 = new Error();

--- a/cjs/initializer.js
+++ b/cjs/initializer.js
@@ -1279,8 +1279,8 @@ function CallHandler(externalCallHandler) {
 function ConfigManager() {
   this.seenConfigs = [];
 }
-function hasPriorityOver(configA, configB) {
-  return configA.appId && !configB.appId;
+function qualifiedConfig(config) {
+  return !!config.appId;
 }
 ConfigManager.prototype = {
   push: function push(config) {
@@ -1334,10 +1334,10 @@ function _processArgs(args, pixelClient, enrichedState, configManager) {
     error('LCPush', 'Failed sending an event', e);
   }
 }
-function _getInitializedLiveConnect(liveConnectConfig) {
+function _getInitializedLiveConnect(liveConnectConfig, initializationCallback) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (hasPriorityOver(window.liQ.config, liveConnectConfig)) {
+      if (qualifiedConfig(window.liQ.config) && !initializationCallback) {
         var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
         if (mismatchedConfig) {
           var error$1 = new Error();
@@ -1421,7 +1421,7 @@ function StandardLiveConnect(liveConnectConfig, externalStorageHandler, external
   try {
     var queue = window.liQ || [];
     var configuration = isObject(liveConnectConfig) && liveConnectConfig || {};
-    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
+    window && (window.liQ = _getInitializedLiveConnect(configuration, initializationCallback) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
     if (isArray(queue)) {
       for (var i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i]);

--- a/cjs/initializer.js
+++ b/cjs/initializer.js
@@ -261,6 +261,10 @@ E.prototype = {
     this.global = other;
     return this;
   },
+  unsetGlobal: function unsetGlobal() {
+    delete this.global;
+    return this;
+  },
   setCurrent: function setCurrent(other) {
     this.current = other;
     return this;
@@ -285,19 +289,19 @@ function init(size, errorCallback, bus) {
       } else {
         if (isFunction(window[EVENT_BUS_NAMESPACE].hierarchical)) {
           var _globalBus = window[EVENT_BUS_NAMESPACE];
-          var _localBus = bus || new E(size);
-          _localBus.setGlobal(_globalBus);
-          _globalBus.setCurrent(_localBus);
-          return _localBus;
+          var localBusOld = window[EVENT_BUS_NAMESPACE].current;
+          var localBusNew = bus || new E(size);
+          localBusNew.setGlobal(_globalBus);
+          _globalBus.setCurrent(localBusNew);
+          localBusOld.unsetGlobal();
+          return localBusNew;
         } else {
           var _globalBus2 = new E(size);
-          var localBusOld = window[EVENT_BUS_NAMESPACE];
-          var localBusNew = bus || new E(size);
-          localBusOld.setGlobal(_globalBus2);
-          localBusNew.setGlobal(_globalBus2);
-          _globalBus2.setCurrent(localBusNew);
+          var _localBusNew = bus || new E(size);
+          _localBusNew.setGlobal(_globalBus2);
+          _globalBus2.setCurrent(_localBusNew);
           window[EVENT_BUS_NAMESPACE] = _globalBus2;
-          return localBusNew;
+          return _localBusNew;
         }
       }
     }

--- a/cjs/standard-live-connect.js
+++ b/cjs/standard-live-connect.js
@@ -201,21 +201,6 @@ E.prototype = {
     }
     return this;
   },
-  last: function last(name, callback, ctx) {
-    var self = this;
-    var eventQueue = this.q[name] || [];
-    if (eventQueue.length > 0) {
-      callback.apply(ctx, eventQueue.last);
-      return this;
-    } else {
-      var listener = function listener() {
-        self.off(name, listener);
-        callback.apply(ctx, arguments);
-      };
-      listener._ = callback;
-      return this.on(name, listener, ctx);
-    }
-  },
   once: function once(name, callback, ctx) {
     var self = this;
     var eventQueue = this.q[name] || [];
@@ -233,17 +218,13 @@ E.prototype = {
   },
   emit: function emit(name) {
     var data = [].slice.call(arguments, 1);
-    var evtArr = (this.h[name] || []).slice();
-    var i = 0;
-    var len = evtArr.length;
-    for (i; i < len; i++) {
-      evtArr[i].fn.apply(evtArr[i].ctx, data);
+    this.emitNoForward(name, data);
+    if (this.global) {
+      this.global.emitNoForward(name, data);
     }
-    var eventQueue = this.q[name] || (this.q[name] = []);
-    if (eventQueue.length >= this.size) {
-      eventQueue.shift();
+    if (this.current) {
+      this.current.emitNoForward(name, data);
     }
-    eventQueue.push(data);
     return this;
   },
   off: function off(name, callback) {
@@ -258,21 +239,68 @@ E.prototype = {
     }
     liveEvents.length ? this.h[name] = liveEvents : delete this.h[name];
     return this;
+  },
+  emitNoForward: function emitNoForward(name, data) {
+    var evtArr = (this.h[name] || []).slice();
+    var i = 0;
+    var len = evtArr.length;
+    for (i; i < len; i++) {
+      evtArr[i].fn.apply(evtArr[i].ctx, data);
+    }
+    var eventQueue = this.q[name] || (this.q[name] = []);
+    if (eventQueue.length >= this.size) {
+      eventQueue.shift();
+    }
+    eventQueue.push(data);
+    return this;
+  },
+  hierarchical: function hierarchical() {
+    return true;
+  },
+  setGlobal: function setGlobal(other) {
+    this.global = other;
+    return this;
+  },
+  setCurrent: function setCurrent(other) {
+    this.current = other;
+    return this;
   }
 };
 
-function init(size, errorCallback) {
+function init(size, errorCallback, bus) {
   if (!size) {
     size = 5;
   }
   try {
     if (!window) {
       errorCallback(new Error('Bus can only be attached to the window, which is not present'));
+    } else {
+      if (!window[EVENT_BUS_NAMESPACE]) {
+        var globalBus = new E(size);
+        var localBus = bus || new E(size);
+        localBus.setGlobal(globalBus);
+        globalBus.setCurrent(localBus);
+        window[EVENT_BUS_NAMESPACE] = globalBus;
+        return localBus;
+      } else {
+        if (isFunction(window[EVENT_BUS_NAMESPACE].hierarchical)) {
+          var _globalBus = window[EVENT_BUS_NAMESPACE];
+          var _localBus = bus || new E(size);
+          _localBus.setGlobal(_globalBus);
+          _globalBus.setCurrent(_localBus);
+          return _localBus;
+        } else {
+          var _globalBus2 = new E(size);
+          var localBusOld = window[EVENT_BUS_NAMESPACE];
+          var localBusNew = bus || new E(size);
+          localBusOld.setGlobal(_globalBus2);
+          localBusNew.setGlobal(_globalBus2);
+          _globalBus2.setCurrent(localBusNew);
+          window[EVENT_BUS_NAMESPACE] = _globalBus2;
+          return localBusNew;
+        }
+      }
     }
-    if (window && !window[EVENT_BUS_NAMESPACE]) {
-      window[EVENT_BUS_NAMESPACE] = new E(size);
-    }
-    return window[EVENT_BUS_NAMESPACE];
   } catch (e) {
     errorCallback(e);
   }
@@ -1331,10 +1359,10 @@ function _processArgs(args, pixelClient, enrichedState, configManager) {
     error('LCPush', 'Failed sending an event', e);
   }
 }
-function _getInitializedLiveConnect(liveConnectConfig, initializationCallback) {
+function _getInitializedLiveConnect(liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (qualifiedConfig(window.liQ.config) && !initializationCallback) {
+      if (!qualifiedConfig(liveConnectConfig)) {
         var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
         if (mismatchedConfig) {
           var error$1 = new Error();
@@ -1348,9 +1376,9 @@ function _getInitializedLiveConnect(liveConnectConfig, initializationCallback) {
   } catch (e) {
   }
 }
-function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
+function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler, localBus) {
   try {
-    init();
+    init(null, null, localBus);
     var callHandler = CallHandler(externalCallHandler);
     var configWithPrivacy = merge(liveConnectConfig, enrich$2(liveConnectConfig));
     register(configWithPrivacy, callHandler);
@@ -1381,7 +1409,6 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
       }
       return _processArgs(args, pixelClient, postManagedState, _configManager);
     };
-    _executeInitializationCallback(initializationCallback, liveConnectConfig);
     return {
       push: _push,
       fire: function fire() {
@@ -1398,11 +1425,6 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
     error('LCConstruction', 'Failed to build LC', x);
   }
 }
-function _executeInitializationCallback(callback, config) {
-  if (callback && isFunction(callback)) {
-    callback(config);
-  }
-}
 function _initializeConfigManager(config) {
   if (window.liQ && window.liQ.configManager) {
     var configManager = window.liQ.configManager;
@@ -1414,11 +1436,11 @@ function _initializeConfigManager(config) {
     return _configManager2;
   }
 }
-function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
+function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler, localBus) {
   try {
     var queue = window.liQ || [];
     var configuration = isObject(liveConnectConfig) && liveConnectConfig || {};
-    window && (window.liQ = _getInitializedLiveConnect(configuration, initializationCallback) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
+    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, localBus) || queue);
     if (isArray(queue)) {
       for (var i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i]);

--- a/cjs/standard-live-connect.js
+++ b/cjs/standard-live-connect.js
@@ -201,6 +201,21 @@ E.prototype = {
     }
     return this;
   },
+  last: function last(name, callback, ctx) {
+    var self = this;
+    var eventQueue = this.q[name] || [];
+    if (eventQueue.length > 0) {
+      callback.apply(ctx, eventQueue.last);
+      return this;
+    } else {
+      var listener = function listener() {
+        self.off(name, listener);
+        callback.apply(ctx, arguments);
+      };
+      listener._ = callback;
+      return this.on(name, listener, ctx);
+    }
+  },
   once: function once(name, callback, ctx) {
     var self = this;
     var eventQueue = this.q[name] || [];
@@ -1258,12 +1273,27 @@ function CallHandler(externalCallHandler) {
   return handler;
 }
 
+function ConfigManager() {
+  this.seenConfigs = [];
+}
+function hasPriorityOver(configA, configB) {
+  return configA.appId && !configB.appId;
+}
+ConfigManager.prototype = {
+  push: function push(config) {
+    this.seenConfigs.push(config);
+  },
+  configs: function configs() {
+    return this.seenConfigs;
+  }
+};
+
 var hemStore = {};
-function _pushSingleEvent(event, pixelClient, enrichedState) {
+function _pushSingleEvent(event, pixelClient, enrichedState, configManager) {
   if (!event || !isObject(event)) {
     error('EventNotAnObject', 'Received event was not an object', new Error(event));
   } else if (event.config) {
-    error('StrayConfig', 'Received a config after LC has already been initialised', new Error(event));
+    configManager.push(event.config);
   } else {
     var combined = enrichedState.combineWith({
       eventSource: event
@@ -1285,16 +1315,16 @@ function _configMatcher(previousConfig, newConfig) {
     };
   }
 }
-function _processArgs(args, pixelClient, enrichedState) {
+function _processArgs(args, pixelClient, enrichedState, configManager) {
   try {
     args.forEach(function (arg) {
       var event = arg;
       if (isArray(event)) {
         event.forEach(function (e) {
-          return _pushSingleEvent(e, pixelClient, enrichedState);
+          return _pushSingleEvent(e, pixelClient, enrichedState, configManager);
         });
       } else {
-        _pushSingleEvent(event, pixelClient, enrichedState);
+        _pushSingleEvent(event, pixelClient, enrichedState, configManager);
       }
     });
   } catch (e) {
@@ -1304,19 +1334,21 @@ function _processArgs(args, pixelClient, enrichedState) {
 function _getInitializedLiveConnect(liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
-      if (mismatchedConfig) {
-        var error$1 = new Error();
-        error$1.name = 'ConfigSent';
-        error$1.message = 'Additional configuration received';
-        error('LCDuplication', JSON.stringify(mismatchedConfig), error$1);
+      if (hasPriorityOver(window.liQ.config, liveConnectConfig)) {
+        var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
+        if (mismatchedConfig) {
+          var error$1 = new Error();
+          error$1.name = 'ConfigSent';
+          error$1.message = 'Additional configuration received';
+          error('LCDuplication', JSON.stringify(mismatchedConfig), error$1);
+        }
+        return window.liQ;
       }
-      return window.liQ;
     }
   } catch (e) {
   }
 }
-function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler) {
+function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
   try {
     init();
     var callHandler = CallHandler(externalCallHandler);
@@ -1342,12 +1374,14 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
     };
     var pixelClient = new PixelSender(configWithPrivacy, callHandler, onPixelLoad, onPixelPreload);
     var resolver = IdentityResolver(postManagedState.data, storageHandler, callHandler);
+    var _configManager = _initializeConfigManager(liveConnectConfig);
     var _push = function _push() {
       for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
         args[_key] = arguments[_key];
       }
-      return _processArgs(args, pixelClient, postManagedState);
+      return _processArgs(args, pixelClient, postManagedState, _configManager);
     };
+    _executeInitializationCallback(initializationCallback, liveConnectConfig);
     return {
       push: _push,
       fire: function fire() {
@@ -1357,17 +1391,34 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
       ready: true,
       resolve: resolver.resolve,
       resolutionCallUrl: resolver.getUrl,
-      config: liveConnectConfig
+      config: liveConnectConfig,
+      configManager: _configManager
     };
   } catch (x) {
     error('LCConstruction', 'Failed to build LC', x);
   }
 }
-function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler) {
+function _executeInitializationCallback(callback, config) {
+  if (callback && isFunction(callback)) {
+    callback(config);
+  }
+}
+function _initializeConfigManager(config) {
+  if (window.liQ && window.liQ.configManager) {
+    var configManager = window.liQ.configManager;
+    configManager.push(config);
+    return configManager;
+  } else {
+    var _configManager2 = new ConfigManager();
+    _configManager2.push(config);
+    return _configManager2;
+  }
+}
+function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
   try {
     var queue = window.liQ || [];
     var configuration = isObject(liveConnectConfig) && liveConnectConfig || {};
-    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler) || queue);
+    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
     if (isArray(queue)) {
       for (var i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i]);

--- a/cjs/standard-live-connect.js
+++ b/cjs/standard-live-connect.js
@@ -261,6 +261,10 @@ E.prototype = {
     this.global = other;
     return this;
   },
+  unsetGlobal: function unsetGlobal() {
+    delete this.global;
+    return this;
+  },
   setCurrent: function setCurrent(other) {
     this.current = other;
     return this;
@@ -285,19 +289,19 @@ function init(size, errorCallback, bus) {
       } else {
         if (isFunction(window[EVENT_BUS_NAMESPACE].hierarchical)) {
           var _globalBus = window[EVENT_BUS_NAMESPACE];
-          var _localBus = bus || new E(size);
-          _localBus.setGlobal(_globalBus);
-          _globalBus.setCurrent(_localBus);
-          return _localBus;
+          var localBusOld = window[EVENT_BUS_NAMESPACE].current;
+          var localBusNew = bus || new E(size);
+          localBusNew.setGlobal(_globalBus);
+          _globalBus.setCurrent(localBusNew);
+          localBusOld.unsetGlobal();
+          return localBusNew;
         } else {
           var _globalBus2 = new E(size);
-          var localBusOld = window[EVENT_BUS_NAMESPACE];
-          var localBusNew = bus || new E(size);
-          localBusOld.setGlobal(_globalBus2);
-          localBusNew.setGlobal(_globalBus2);
-          _globalBus2.setCurrent(localBusNew);
+          var _localBusNew = bus || new E(size);
+          _localBusNew.setGlobal(_globalBus2);
+          _globalBus2.setCurrent(_localBusNew);
           window[EVENT_BUS_NAMESPACE] = _globalBus2;
-          return localBusNew;
+          return _localBusNew;
         }
       }
     }

--- a/cjs/standard-live-connect.js
+++ b/cjs/standard-live-connect.js
@@ -884,8 +884,8 @@ function _pixelError(error) {
 }
 function register(state, callHandler) {
   try {
-    if (window && window[EVENT_BUS_NAMESPACE] && isFunction(window[EVENT_BUS_NAMESPACE].on)) {
-      window[EVENT_BUS_NAMESPACE].on(ERRORS_PREFIX, _pixelError);
+    if (window && window[EVENT_BUS_NAMESPACE] && window[EVENT_BUS_NAMESPACE].current && isFunction(window[EVENT_BUS_NAMESPACE].current.on)) {
+      window[EVENT_BUS_NAMESPACE].current.on(ERRORS_PREFIX, _pixelError);
     }
     _pixelSender = new PixelSender(state, callHandler);
     _state = state || {};
@@ -1362,7 +1362,7 @@ function _processArgs(args, pixelClient, enrichedState, configManager) {
 function _getInitializedLiveConnect(liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (!qualifiedConfig(liveConnectConfig)) {
+      if (qualifiedConfig(window.liQ.config) || !qualifiedConfig(liveConnectConfig)) {
         var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
         if (mismatchedConfig) {
           var error$1 = new Error();

--- a/cjs/standard-live-connect.js
+++ b/cjs/standard-live-connect.js
@@ -1276,8 +1276,8 @@ function CallHandler(externalCallHandler) {
 function ConfigManager() {
   this.seenConfigs = [];
 }
-function hasPriorityOver(configA, configB) {
-  return configA.appId && !configB.appId;
+function qualifiedConfig(config) {
+  return !!config.appId;
 }
 ConfigManager.prototype = {
   push: function push(config) {
@@ -1331,10 +1331,10 @@ function _processArgs(args, pixelClient, enrichedState, configManager) {
     error('LCPush', 'Failed sending an event', e);
   }
 }
-function _getInitializedLiveConnect(liveConnectConfig) {
+function _getInitializedLiveConnect(liveConnectConfig, initializationCallback) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (hasPriorityOver(window.liQ.config, liveConnectConfig)) {
+      if (qualifiedConfig(window.liQ.config) && !initializationCallback) {
         var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
         if (mismatchedConfig) {
           var error$1 = new Error();
@@ -1418,7 +1418,7 @@ function StandardLiveConnect(liveConnectConfig, externalStorageHandler, external
   try {
     var queue = window.liQ || [];
     var configuration = isObject(liveConnectConfig) && liveConnectConfig || {};
-    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
+    window && (window.liQ = _getInitializedLiveConnect(configuration, initializationCallback) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
     if (isArray(queue)) {
       for (var i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i]);

--- a/esm/initializer.js
+++ b/esm/initializer.js
@@ -257,6 +257,10 @@ E.prototype = {
     this.global = other;
     return this;
   },
+  unsetGlobal: function unsetGlobal() {
+    delete this.global;
+    return this;
+  },
   setCurrent: function setCurrent(other) {
     this.current = other;
     return this;
@@ -281,19 +285,19 @@ function init(size, errorCallback, bus) {
       } else {
         if (isFunction(window[EVENT_BUS_NAMESPACE].hierarchical)) {
           var _globalBus = window[EVENT_BUS_NAMESPACE];
-          var _localBus = bus || new E(size);
-          _localBus.setGlobal(_globalBus);
-          _globalBus.setCurrent(_localBus);
-          return _localBus;
+          var localBusOld = window[EVENT_BUS_NAMESPACE].current;
+          var localBusNew = bus || new E(size);
+          localBusNew.setGlobal(_globalBus);
+          _globalBus.setCurrent(localBusNew);
+          localBusOld.unsetGlobal();
+          return localBusNew;
         } else {
           var _globalBus2 = new E(size);
-          var localBusOld = window[EVENT_BUS_NAMESPACE];
-          var localBusNew = bus || new E(size);
-          localBusOld.setGlobal(_globalBus2);
-          localBusNew.setGlobal(_globalBus2);
-          _globalBus2.setCurrent(localBusNew);
+          var _localBusNew = bus || new E(size);
+          _localBusNew.setGlobal(_globalBus2);
+          _globalBus2.setCurrent(_localBusNew);
           window[EVENT_BUS_NAMESPACE] = _globalBus2;
-          return localBusNew;
+          return _localBusNew;
         }
       }
     }

--- a/esm/initializer.js
+++ b/esm/initializer.js
@@ -197,6 +197,21 @@ E.prototype = {
     }
     return this;
   },
+  last: function last(name, callback, ctx) {
+    var self = this;
+    var eventQueue = this.q[name] || [];
+    if (eventQueue.length > 0) {
+      callback.apply(ctx, eventQueue.last);
+      return this;
+    } else {
+      var listener = function listener() {
+        self.off(name, listener);
+        callback.apply(ctx, arguments);
+      };
+      listener._ = callback;
+      return this.on(name, listener, ctx);
+    }
+  },
   once: function once(name, callback, ctx) {
     var self = this;
     var eventQueue = this.q[name] || [];
@@ -1257,12 +1272,27 @@ function CallHandler(externalCallHandler) {
   return handler;
 }
 
+function ConfigManager() {
+  this.seenConfigs = [];
+}
+function hasPriorityOver(configA, configB) {
+  return configA.appId && !configB.appId;
+}
+ConfigManager.prototype = {
+  push: function push(config) {
+    this.seenConfigs.push(config);
+  },
+  configs: function configs() {
+    return this.seenConfigs;
+  }
+};
+
 var hemStore = {};
-function _pushSingleEvent(event, pixelClient, enrichedState) {
+function _pushSingleEvent(event, pixelClient, enrichedState, configManager) {
   if (!event || !isObject(event)) {
     error('EventNotAnObject', 'Received event was not an object', new Error(event));
   } else if (event.config) {
-    error('StrayConfig', 'Received a config after LC has already been initialised', new Error(event));
+    configManager.push(event.config);
   } else {
     var combined = enrichedState.combineWith({
       eventSource: event
@@ -1284,16 +1314,16 @@ function _configMatcher(previousConfig, newConfig) {
     };
   }
 }
-function _processArgs(args, pixelClient, enrichedState) {
+function _processArgs(args, pixelClient, enrichedState, configManager) {
   try {
     args.forEach(function (arg) {
       var event = arg;
       if (isArray(event)) {
         event.forEach(function (e) {
-          return _pushSingleEvent(e, pixelClient, enrichedState);
+          return _pushSingleEvent(e, pixelClient, enrichedState, configManager);
         });
       } else {
-        _pushSingleEvent(event, pixelClient, enrichedState);
+        _pushSingleEvent(event, pixelClient, enrichedState, configManager);
       }
     });
   } catch (e) {
@@ -1303,19 +1333,21 @@ function _processArgs(args, pixelClient, enrichedState) {
 function _getInitializedLiveConnect(liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
-      if (mismatchedConfig) {
-        var error$1 = new Error();
-        error$1.name = 'ConfigSent';
-        error$1.message = 'Additional configuration received';
-        error('LCDuplication', JSON.stringify(mismatchedConfig), error$1);
+      if (hasPriorityOver(window.liQ.config, liveConnectConfig)) {
+        var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
+        if (mismatchedConfig) {
+          var error$1 = new Error();
+          error$1.name = 'ConfigSent';
+          error$1.message = 'Additional configuration received';
+          error('LCDuplication', JSON.stringify(mismatchedConfig), error$1);
+        }
+        return window.liQ;
       }
-      return window.liQ;
     }
   } catch (e) {
   }
 }
-function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler) {
+function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
   try {
     init();
     var callHandler = CallHandler(externalCallHandler);
@@ -1341,12 +1373,14 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
     };
     var pixelClient = new PixelSender(configWithPrivacy, callHandler, onPixelLoad, onPixelPreload);
     var resolver = IdentityResolver(postManagedState.data, storageHandler, callHandler);
+    var _configManager = _initializeConfigManager(liveConnectConfig);
     var _push = function _push() {
       for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
         args[_key] = arguments[_key];
       }
-      return _processArgs(args, pixelClient, postManagedState);
+      return _processArgs(args, pixelClient, postManagedState, _configManager);
     };
+    _executeInitializationCallback(initializationCallback, liveConnectConfig);
     return {
       push: _push,
       fire: function fire() {
@@ -1356,17 +1390,34 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
       ready: true,
       resolve: resolver.resolve,
       resolutionCallUrl: resolver.getUrl,
-      config: liveConnectConfig
+      config: liveConnectConfig,
+      configManager: _configManager
     };
   } catch (x) {
     error('LCConstruction', 'Failed to build LC', x);
   }
 }
-function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler) {
+function _executeInitializationCallback(callback, config) {
+  if (callback && isFunction(callback)) {
+    callback(config);
+  }
+}
+function _initializeConfigManager(config) {
+  if (window.liQ && window.liQ.configManager) {
+    var configManager = window.liQ.configManager;
+    configManager.push(config);
+    return configManager;
+  } else {
+    var _configManager2 = new ConfigManager();
+    _configManager2.push(config);
+    return _configManager2;
+  }
+}
+function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
   try {
     var queue = window.liQ || [];
     var configuration = isObject(liveConnectConfig) && liveConnectConfig || {};
-    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler) || queue);
+    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
     if (isArray(queue)) {
       for (var i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i]);

--- a/esm/initializer.js
+++ b/esm/initializer.js
@@ -1275,8 +1275,8 @@ function CallHandler(externalCallHandler) {
 function ConfigManager() {
   this.seenConfigs = [];
 }
-function hasPriorityOver(configA, configB) {
-  return configA.appId && !configB.appId;
+function qualifiedConfig(config) {
+  return !!config.appId;
 }
 ConfigManager.prototype = {
   push: function push(config) {
@@ -1330,10 +1330,10 @@ function _processArgs(args, pixelClient, enrichedState, configManager) {
     error('LCPush', 'Failed sending an event', e);
   }
 }
-function _getInitializedLiveConnect(liveConnectConfig) {
+function _getInitializedLiveConnect(liveConnectConfig, initializationCallback) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (hasPriorityOver(window.liQ.config, liveConnectConfig)) {
+      if (qualifiedConfig(window.liQ.config) && !initializationCallback) {
         var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
         if (mismatchedConfig) {
           var error$1 = new Error();
@@ -1417,7 +1417,7 @@ function StandardLiveConnect(liveConnectConfig, externalStorageHandler, external
   try {
     var queue = window.liQ || [];
     var configuration = isObject(liveConnectConfig) && liveConnectConfig || {};
-    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
+    window && (window.liQ = _getInitializedLiveConnect(configuration, initializationCallback) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
     if (isArray(queue)) {
       for (var i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i]);

--- a/esm/initializer.js
+++ b/esm/initializer.js
@@ -197,21 +197,6 @@ E.prototype = {
     }
     return this;
   },
-  last: function last(name, callback, ctx) {
-    var self = this;
-    var eventQueue = this.q[name] || [];
-    if (eventQueue.length > 0) {
-      callback.apply(ctx, eventQueue.last);
-      return this;
-    } else {
-      var listener = function listener() {
-        self.off(name, listener);
-        callback.apply(ctx, arguments);
-      };
-      listener._ = callback;
-      return this.on(name, listener, ctx);
-    }
-  },
   once: function once(name, callback, ctx) {
     var self = this;
     var eventQueue = this.q[name] || [];
@@ -229,17 +214,13 @@ E.prototype = {
   },
   emit: function emit(name) {
     var data = [].slice.call(arguments, 1);
-    var evtArr = (this.h[name] || []).slice();
-    var i = 0;
-    var len = evtArr.length;
-    for (i; i < len; i++) {
-      evtArr[i].fn.apply(evtArr[i].ctx, data);
+    this.emitNoForward(name, data);
+    if (this.global) {
+      this.global.emitNoForward(name, data);
     }
-    var eventQueue = this.q[name] || (this.q[name] = []);
-    if (eventQueue.length >= this.size) {
-      eventQueue.shift();
+    if (this.current) {
+      this.current.emitNoForward(name, data);
     }
-    eventQueue.push(data);
     return this;
   },
   off: function off(name, callback) {
@@ -254,21 +235,68 @@ E.prototype = {
     }
     liveEvents.length ? this.h[name] = liveEvents : delete this.h[name];
     return this;
+  },
+  emitNoForward: function emitNoForward(name, data) {
+    var evtArr = (this.h[name] || []).slice();
+    var i = 0;
+    var len = evtArr.length;
+    for (i; i < len; i++) {
+      evtArr[i].fn.apply(evtArr[i].ctx, data);
+    }
+    var eventQueue = this.q[name] || (this.q[name] = []);
+    if (eventQueue.length >= this.size) {
+      eventQueue.shift();
+    }
+    eventQueue.push(data);
+    return this;
+  },
+  hierarchical: function hierarchical() {
+    return true;
+  },
+  setGlobal: function setGlobal(other) {
+    this.global = other;
+    return this;
+  },
+  setCurrent: function setCurrent(other) {
+    this.current = other;
+    return this;
   }
 };
 
-function init(size, errorCallback) {
+function init(size, errorCallback, bus) {
   if (!size) {
     size = 5;
   }
   try {
     if (!window) {
       errorCallback(new Error('Bus can only be attached to the window, which is not present'));
+    } else {
+      if (!window[EVENT_BUS_NAMESPACE]) {
+        var globalBus = new E(size);
+        var localBus = bus || new E(size);
+        localBus.setGlobal(globalBus);
+        globalBus.setCurrent(localBus);
+        window[EVENT_BUS_NAMESPACE] = globalBus;
+        return localBus;
+      } else {
+        if (isFunction(window[EVENT_BUS_NAMESPACE].hierarchical)) {
+          var _globalBus = window[EVENT_BUS_NAMESPACE];
+          var _localBus = bus || new E(size);
+          _localBus.setGlobal(_globalBus);
+          _globalBus.setCurrent(_localBus);
+          return _localBus;
+        } else {
+          var _globalBus2 = new E(size);
+          var localBusOld = window[EVENT_BUS_NAMESPACE];
+          var localBusNew = bus || new E(size);
+          localBusOld.setGlobal(_globalBus2);
+          localBusNew.setGlobal(_globalBus2);
+          _globalBus2.setCurrent(localBusNew);
+          window[EVENT_BUS_NAMESPACE] = _globalBus2;
+          return localBusNew;
+        }
+      }
     }
-    if (window && !window[EVENT_BUS_NAMESPACE]) {
-      window[EVENT_BUS_NAMESPACE] = new E(size);
-    }
-    return window[EVENT_BUS_NAMESPACE];
   } catch (e) {
     errorCallback(e);
   }
@@ -1330,10 +1358,10 @@ function _processArgs(args, pixelClient, enrichedState, configManager) {
     error('LCPush', 'Failed sending an event', e);
   }
 }
-function _getInitializedLiveConnect(liveConnectConfig, initializationCallback) {
+function _getInitializedLiveConnect(liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (qualifiedConfig(window.liQ.config) && !initializationCallback) {
+      if (!qualifiedConfig(liveConnectConfig)) {
         var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
         if (mismatchedConfig) {
           var error$1 = new Error();
@@ -1347,9 +1375,9 @@ function _getInitializedLiveConnect(liveConnectConfig, initializationCallback) {
   } catch (e) {
   }
 }
-function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
+function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler, localBus) {
   try {
-    init();
+    init(null, null, localBus);
     var callHandler = CallHandler(externalCallHandler);
     var configWithPrivacy = merge(liveConnectConfig, enrich$2(liveConnectConfig));
     register(configWithPrivacy, callHandler);
@@ -1380,7 +1408,6 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
       }
       return _processArgs(args, pixelClient, postManagedState, _configManager);
     };
-    _executeInitializationCallback(initializationCallback, liveConnectConfig);
     return {
       push: _push,
       fire: function fire() {
@@ -1397,11 +1424,6 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
     error('LCConstruction', 'Failed to build LC', x);
   }
 }
-function _executeInitializationCallback(callback, config) {
-  if (callback && isFunction(callback)) {
-    callback(config);
-  }
-}
 function _initializeConfigManager(config) {
   if (window.liQ && window.liQ.configManager) {
     var configManager = window.liQ.configManager;
@@ -1413,11 +1435,11 @@ function _initializeConfigManager(config) {
     return _configManager2;
   }
 }
-function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
+function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler, localBus) {
   try {
     var queue = window.liQ || [];
     var configuration = isObject(liveConnectConfig) && liveConnectConfig || {};
-    window && (window.liQ = _getInitializedLiveConnect(configuration, initializationCallback) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
+    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, localBus) || queue);
     if (isArray(queue)) {
       for (var i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i]);

--- a/esm/initializer.js
+++ b/esm/initializer.js
@@ -883,8 +883,8 @@ function _pixelError(error) {
 }
 function register(state, callHandler) {
   try {
-    if (window && window[EVENT_BUS_NAMESPACE] && isFunction(window[EVENT_BUS_NAMESPACE].on)) {
-      window[EVENT_BUS_NAMESPACE].on(ERRORS_PREFIX, _pixelError);
+    if (window && window[EVENT_BUS_NAMESPACE] && window[EVENT_BUS_NAMESPACE].current && isFunction(window[EVENT_BUS_NAMESPACE].current.on)) {
+      window[EVENT_BUS_NAMESPACE].current.on(ERRORS_PREFIX, _pixelError);
     }
     _pixelSender = new PixelSender(state, callHandler);
     _state = state || {};
@@ -1361,7 +1361,7 @@ function _processArgs(args, pixelClient, enrichedState, configManager) {
 function _getInitializedLiveConnect(liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (!qualifiedConfig(liveConnectConfig)) {
+      if (qualifiedConfig(window.liQ.config) || !qualifiedConfig(liveConnectConfig)) {
         var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
         if (mismatchedConfig) {
           var error$1 = new Error();

--- a/esm/standard-live-connect.js
+++ b/esm/standard-live-connect.js
@@ -257,6 +257,10 @@ E.prototype = {
     this.global = other;
     return this;
   },
+  unsetGlobal: function unsetGlobal() {
+    delete this.global;
+    return this;
+  },
   setCurrent: function setCurrent(other) {
     this.current = other;
     return this;
@@ -281,19 +285,19 @@ function init(size, errorCallback, bus) {
       } else {
         if (isFunction(window[EVENT_BUS_NAMESPACE].hierarchical)) {
           var _globalBus = window[EVENT_BUS_NAMESPACE];
-          var _localBus = bus || new E(size);
-          _localBus.setGlobal(_globalBus);
-          _globalBus.setCurrent(_localBus);
-          return _localBus;
+          var localBusOld = window[EVENT_BUS_NAMESPACE].current;
+          var localBusNew = bus || new E(size);
+          localBusNew.setGlobal(_globalBus);
+          _globalBus.setCurrent(localBusNew);
+          localBusOld.unsetGlobal();
+          return localBusNew;
         } else {
           var _globalBus2 = new E(size);
-          var localBusOld = window[EVENT_BUS_NAMESPACE];
-          var localBusNew = bus || new E(size);
-          localBusOld.setGlobal(_globalBus2);
-          localBusNew.setGlobal(_globalBus2);
-          _globalBus2.setCurrent(localBusNew);
+          var _localBusNew = bus || new E(size);
+          _localBusNew.setGlobal(_globalBus2);
+          _globalBus2.setCurrent(_localBusNew);
           window[EVENT_BUS_NAMESPACE] = _globalBus2;
-          return localBusNew;
+          return _localBusNew;
         }
       }
     }

--- a/esm/standard-live-connect.js
+++ b/esm/standard-live-connect.js
@@ -197,21 +197,6 @@ E.prototype = {
     }
     return this;
   },
-  last: function last(name, callback, ctx) {
-    var self = this;
-    var eventQueue = this.q[name] || [];
-    if (eventQueue.length > 0) {
-      callback.apply(ctx, eventQueue.last);
-      return this;
-    } else {
-      var listener = function listener() {
-        self.off(name, listener);
-        callback.apply(ctx, arguments);
-      };
-      listener._ = callback;
-      return this.on(name, listener, ctx);
-    }
-  },
   once: function once(name, callback, ctx) {
     var self = this;
     var eventQueue = this.q[name] || [];
@@ -229,17 +214,13 @@ E.prototype = {
   },
   emit: function emit(name) {
     var data = [].slice.call(arguments, 1);
-    var evtArr = (this.h[name] || []).slice();
-    var i = 0;
-    var len = evtArr.length;
-    for (i; i < len; i++) {
-      evtArr[i].fn.apply(evtArr[i].ctx, data);
+    this.emitNoForward(name, data);
+    if (this.global) {
+      this.global.emitNoForward(name, data);
     }
-    var eventQueue = this.q[name] || (this.q[name] = []);
-    if (eventQueue.length >= this.size) {
-      eventQueue.shift();
+    if (this.current) {
+      this.current.emitNoForward(name, data);
     }
-    eventQueue.push(data);
     return this;
   },
   off: function off(name, callback) {
@@ -254,21 +235,68 @@ E.prototype = {
     }
     liveEvents.length ? this.h[name] = liveEvents : delete this.h[name];
     return this;
+  },
+  emitNoForward: function emitNoForward(name, data) {
+    var evtArr = (this.h[name] || []).slice();
+    var i = 0;
+    var len = evtArr.length;
+    for (i; i < len; i++) {
+      evtArr[i].fn.apply(evtArr[i].ctx, data);
+    }
+    var eventQueue = this.q[name] || (this.q[name] = []);
+    if (eventQueue.length >= this.size) {
+      eventQueue.shift();
+    }
+    eventQueue.push(data);
+    return this;
+  },
+  hierarchical: function hierarchical() {
+    return true;
+  },
+  setGlobal: function setGlobal(other) {
+    this.global = other;
+    return this;
+  },
+  setCurrent: function setCurrent(other) {
+    this.current = other;
+    return this;
   }
 };
 
-function init(size, errorCallback) {
+function init(size, errorCallback, bus) {
   if (!size) {
     size = 5;
   }
   try {
     if (!window) {
       errorCallback(new Error('Bus can only be attached to the window, which is not present'));
+    } else {
+      if (!window[EVENT_BUS_NAMESPACE]) {
+        var globalBus = new E(size);
+        var localBus = bus || new E(size);
+        localBus.setGlobal(globalBus);
+        globalBus.setCurrent(localBus);
+        window[EVENT_BUS_NAMESPACE] = globalBus;
+        return localBus;
+      } else {
+        if (isFunction(window[EVENT_BUS_NAMESPACE].hierarchical)) {
+          var _globalBus = window[EVENT_BUS_NAMESPACE];
+          var _localBus = bus || new E(size);
+          _localBus.setGlobal(_globalBus);
+          _globalBus.setCurrent(_localBus);
+          return _localBus;
+        } else {
+          var _globalBus2 = new E(size);
+          var localBusOld = window[EVENT_BUS_NAMESPACE];
+          var localBusNew = bus || new E(size);
+          localBusOld.setGlobal(_globalBus2);
+          localBusNew.setGlobal(_globalBus2);
+          _globalBus2.setCurrent(localBusNew);
+          window[EVENT_BUS_NAMESPACE] = _globalBus2;
+          return localBusNew;
+        }
+      }
     }
-    if (window && !window[EVENT_BUS_NAMESPACE]) {
-      window[EVENT_BUS_NAMESPACE] = new E(size);
-    }
-    return window[EVENT_BUS_NAMESPACE];
   } catch (e) {
     errorCallback(e);
   }
@@ -1327,10 +1355,10 @@ function _processArgs(args, pixelClient, enrichedState, configManager) {
     error('LCPush', 'Failed sending an event', e);
   }
 }
-function _getInitializedLiveConnect(liveConnectConfig, initializationCallback) {
+function _getInitializedLiveConnect(liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (qualifiedConfig(window.liQ.config) && !initializationCallback) {
+      if (!qualifiedConfig(liveConnectConfig)) {
         var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
         if (mismatchedConfig) {
           var error$1 = new Error();
@@ -1344,9 +1372,9 @@ function _getInitializedLiveConnect(liveConnectConfig, initializationCallback) {
   } catch (e) {
   }
 }
-function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
+function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler, localBus) {
   try {
-    init();
+    init(null, null, localBus);
     var callHandler = CallHandler(externalCallHandler);
     var configWithPrivacy = merge(liveConnectConfig, enrich$2(liveConnectConfig));
     register(configWithPrivacy, callHandler);
@@ -1377,7 +1405,6 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
       }
       return _processArgs(args, pixelClient, postManagedState, _configManager);
     };
-    _executeInitializationCallback(initializationCallback, liveConnectConfig);
     return {
       push: _push,
       fire: function fire() {
@@ -1394,11 +1421,6 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
     error('LCConstruction', 'Failed to build LC', x);
   }
 }
-function _executeInitializationCallback(callback, config) {
-  if (callback && isFunction(callback)) {
-    callback(config);
-  }
-}
 function _initializeConfigManager(config) {
   if (window.liQ && window.liQ.configManager) {
     var configManager = window.liQ.configManager;
@@ -1410,11 +1432,11 @@ function _initializeConfigManager(config) {
     return _configManager2;
   }
 }
-function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
+function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler, localBus) {
   try {
     var queue = window.liQ || [];
     var configuration = isObject(liveConnectConfig) && liveConnectConfig || {};
-    window && (window.liQ = _getInitializedLiveConnect(configuration, initializationCallback) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
+    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, localBus) || queue);
     if (isArray(queue)) {
       for (var i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i]);

--- a/esm/standard-live-connect.js
+++ b/esm/standard-live-connect.js
@@ -197,6 +197,21 @@ E.prototype = {
     }
     return this;
   },
+  last: function last(name, callback, ctx) {
+    var self = this;
+    var eventQueue = this.q[name] || [];
+    if (eventQueue.length > 0) {
+      callback.apply(ctx, eventQueue.last);
+      return this;
+    } else {
+      var listener = function listener() {
+        self.off(name, listener);
+        callback.apply(ctx, arguments);
+      };
+      listener._ = callback;
+      return this.on(name, listener, ctx);
+    }
+  },
   once: function once(name, callback, ctx) {
     var self = this;
     var eventQueue = this.q[name] || [];
@@ -1254,12 +1269,27 @@ function CallHandler(externalCallHandler) {
   return handler;
 }
 
+function ConfigManager() {
+  this.seenConfigs = [];
+}
+function hasPriorityOver(configA, configB) {
+  return configA.appId && !configB.appId;
+}
+ConfigManager.prototype = {
+  push: function push(config) {
+    this.seenConfigs.push(config);
+  },
+  configs: function configs() {
+    return this.seenConfigs;
+  }
+};
+
 var hemStore = {};
-function _pushSingleEvent(event, pixelClient, enrichedState) {
+function _pushSingleEvent(event, pixelClient, enrichedState, configManager) {
   if (!event || !isObject(event)) {
     error('EventNotAnObject', 'Received event was not an object', new Error(event));
   } else if (event.config) {
-    error('StrayConfig', 'Received a config after LC has already been initialised', new Error(event));
+    configManager.push(event.config);
   } else {
     var combined = enrichedState.combineWith({
       eventSource: event
@@ -1281,16 +1311,16 @@ function _configMatcher(previousConfig, newConfig) {
     };
   }
 }
-function _processArgs(args, pixelClient, enrichedState) {
+function _processArgs(args, pixelClient, enrichedState, configManager) {
   try {
     args.forEach(function (arg) {
       var event = arg;
       if (isArray(event)) {
         event.forEach(function (e) {
-          return _pushSingleEvent(e, pixelClient, enrichedState);
+          return _pushSingleEvent(e, pixelClient, enrichedState, configManager);
         });
       } else {
-        _pushSingleEvent(event, pixelClient, enrichedState);
+        _pushSingleEvent(event, pixelClient, enrichedState, configManager);
       }
     });
   } catch (e) {
@@ -1300,19 +1330,21 @@ function _processArgs(args, pixelClient, enrichedState) {
 function _getInitializedLiveConnect(liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
-      if (mismatchedConfig) {
-        var error$1 = new Error();
-        error$1.name = 'ConfigSent';
-        error$1.message = 'Additional configuration received';
-        error('LCDuplication', JSON.stringify(mismatchedConfig), error$1);
+      if (hasPriorityOver(window.liQ.config, liveConnectConfig)) {
+        var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
+        if (mismatchedConfig) {
+          var error$1 = new Error();
+          error$1.name = 'ConfigSent';
+          error$1.message = 'Additional configuration received';
+          error('LCDuplication', JSON.stringify(mismatchedConfig), error$1);
+        }
+        return window.liQ;
       }
-      return window.liQ;
     }
   } catch (e) {
   }
 }
-function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler) {
+function _standardInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
   try {
     init();
     var callHandler = CallHandler(externalCallHandler);
@@ -1338,12 +1370,14 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
     };
     var pixelClient = new PixelSender(configWithPrivacy, callHandler, onPixelLoad, onPixelPreload);
     var resolver = IdentityResolver(postManagedState.data, storageHandler, callHandler);
+    var _configManager = _initializeConfigManager(liveConnectConfig);
     var _push = function _push() {
       for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
         args[_key] = arguments[_key];
       }
-      return _processArgs(args, pixelClient, postManagedState);
+      return _processArgs(args, pixelClient, postManagedState, _configManager);
     };
+    _executeInitializationCallback(initializationCallback, liveConnectConfig);
     return {
       push: _push,
       fire: function fire() {
@@ -1353,17 +1387,34 @@ function _standardInitialization(liveConnectConfig, externalStorageHandler, exte
       ready: true,
       resolve: resolver.resolve,
       resolutionCallUrl: resolver.getUrl,
-      config: liveConnectConfig
+      config: liveConnectConfig,
+      configManager: _configManager
     };
   } catch (x) {
     error('LCConstruction', 'Failed to build LC', x);
   }
 }
-function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler) {
+function _executeInitializationCallback(callback, config) {
+  if (callback && isFunction(callback)) {
+    callback(config);
+  }
+}
+function _initializeConfigManager(config) {
+  if (window.liQ && window.liQ.configManager) {
+    var configManager = window.liQ.configManager;
+    configManager.push(config);
+    return configManager;
+  } else {
+    var _configManager2 = new ConfigManager();
+    _configManager2.push(config);
+    return _configManager2;
+  }
+}
+function StandardLiveConnect(liveConnectConfig, externalStorageHandler, externalCallHandler, initializationCallback) {
   try {
     var queue = window.liQ || [];
     var configuration = isObject(liveConnectConfig) && liveConnectConfig || {};
-    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler) || queue);
+    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
     if (isArray(queue)) {
       for (var i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i]);

--- a/esm/standard-live-connect.js
+++ b/esm/standard-live-connect.js
@@ -880,8 +880,8 @@ function _pixelError(error) {
 }
 function register(state, callHandler) {
   try {
-    if (window && window[EVENT_BUS_NAMESPACE] && isFunction(window[EVENT_BUS_NAMESPACE].on)) {
-      window[EVENT_BUS_NAMESPACE].on(ERRORS_PREFIX, _pixelError);
+    if (window && window[EVENT_BUS_NAMESPACE] && window[EVENT_BUS_NAMESPACE].current && isFunction(window[EVENT_BUS_NAMESPACE].current.on)) {
+      window[EVENT_BUS_NAMESPACE].current.on(ERRORS_PREFIX, _pixelError);
     }
     _pixelSender = new PixelSender(state, callHandler);
     _state = state || {};
@@ -1358,7 +1358,7 @@ function _processArgs(args, pixelClient, enrichedState, configManager) {
 function _getInitializedLiveConnect(liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (!qualifiedConfig(liveConnectConfig)) {
+      if (qualifiedConfig(window.liQ.config) || !qualifiedConfig(liveConnectConfig)) {
         var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
         if (mismatchedConfig) {
           var error$1 = new Error();

--- a/esm/standard-live-connect.js
+++ b/esm/standard-live-connect.js
@@ -1272,8 +1272,8 @@ function CallHandler(externalCallHandler) {
 function ConfigManager() {
   this.seenConfigs = [];
 }
-function hasPriorityOver(configA, configB) {
-  return configA.appId && !configB.appId;
+function qualifiedConfig(config) {
+  return !!config.appId;
 }
 ConfigManager.prototype = {
   push: function push(config) {
@@ -1327,10 +1327,10 @@ function _processArgs(args, pixelClient, enrichedState, configManager) {
     error('LCPush', 'Failed sending an event', e);
   }
 }
-function _getInitializedLiveConnect(liveConnectConfig) {
+function _getInitializedLiveConnect(liveConnectConfig, initializationCallback) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (hasPriorityOver(window.liQ.config, liveConnectConfig)) {
+      if (qualifiedConfig(window.liQ.config) && !initializationCallback) {
         var mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig);
         if (mismatchedConfig) {
           var error$1 = new Error();
@@ -1414,7 +1414,7 @@ function StandardLiveConnect(liveConnectConfig, externalStorageHandler, external
   try {
     var queue = window.liQ || [];
     var configuration = isObject(liveConnectConfig) && liveConnectConfig || {};
-    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
+    window && (window.liQ = _getInitializedLiveConnect(configuration, initializationCallback) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue);
     if (isArray(queue)) {
       for (var i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i]);

--- a/src/config/config-manager.js
+++ b/src/config/config-manager.js
@@ -3,10 +3,6 @@ export default function ConfigManager () {
   this.seenConfigs = []
 }
 
-export function hasPriorityOver (configA, configB) {
-  return qualifiedConfig(configA) && !qualifiedConfig(configB)
-}
-
 export function qualifiedConfig (config) {
   return !!config.appId
 }

--- a/src/config/config-manager.js
+++ b/src/config/config-manager.js
@@ -1,0 +1,22 @@
+
+export default function ConfigManager () {
+  this.seenConfigs = []
+}
+
+export function hasPriorityOver (configA, configB) {
+  return qualifiedConfig(configA) && !qualifiedConfig(configB)
+}
+
+export function qualifiedConfig (config) {
+  return !!config.appId
+}
+
+ConfigManager.prototype = {
+  push: function (config) {
+    this.seenConfigs.push(config)
+  },
+
+  configs: function () {
+    return this.seenConfigs
+  }
+}

--- a/src/events/bus.js
+++ b/src/events/bus.js
@@ -1,4 +1,4 @@
-import E, { fromBus, reset } from './replayemitter'
+import E, { fromBusReset } from './replayemitter'
 import * as C from '../utils/consts'
 import { isFunction } from '../utils/types'
 
@@ -31,14 +31,15 @@ export function init (size, errorCallback, bus) {
         if (isFunction(window[C.EVENT_BUS_NAMESPACE].hierarchical)) {
           const globalBus = window[C.EVENT_BUS_NAMESPACE]
           const localBusNew = bus || new E(size)
+          const localBusOld = window[C.EVENT_BUS_NAMESPACE].current
           localBusNew.setGlobal(globalBus)
+          localBusOld.unsetGlobal()
           globalBus.setCurrent(localBusNew)
           return localBusNew
         } else {
           // We keep the old global bus' state in the new global bus.
           const globalBusOld = window[C.EVENT_BUS_NAMESPACE]
-          const globalBusNew = fromBus(globalBusOld)
-          reset(globalBusOld)
+          const globalBusNew = fromBusReset(globalBusOld)
           const localBusNew = bus || new E(size)
           localBusNew.setGlobal(globalBusNew)
           globalBusNew.setCurrent(localBusNew)

--- a/src/events/bus.js
+++ b/src/events/bus.js
@@ -1,6 +1,10 @@
 import E from './replayemitter'
 import * as C from '../utils/consts'
 
+export function local (size) {
+  return new E(size)
+}
+
 /**
  * @param {number} size
  * @param {function} errorCallback

--- a/src/events/bus.js
+++ b/src/events/bus.js
@@ -30,15 +30,16 @@ export function init (size, errorCallback, bus) {
       } else {
         if (isFunction(window[C.EVENT_BUS_NAMESPACE].hierarchical)) {
           const globalBus = window[C.EVENT_BUS_NAMESPACE]
-          const localBus = bus || new E(size)
-          localBus.setGlobal(globalBus)
-          globalBus.setCurrent(localBus)
-          return localBus
-        } else {
-          const globalBus = new E(size)
-          const localBusOld = window[C.EVENT_BUS_NAMESPACE]
+          const localBusOld = window[C.EVENT_BUS_NAMESPACE].current
           const localBusNew = bus || new E(size)
-          localBusOld.setGlobal(globalBus)
+          localBusNew.setGlobal(globalBus)
+          globalBus.setCurrent(localBusNew)
+          localBusOld.unsetGlobal()
+          return localBusNew
+        } else {
+          // This will lead to losing all global bus listeners
+          const globalBus = new E(size)
+          const localBusNew = bus || new E(size)
           localBusNew.setGlobal(globalBus)
           globalBus.setCurrent(localBusNew)
           window[C.EVENT_BUS_NAMESPACE] = globalBus

--- a/src/events/bus.js
+++ b/src/events/bus.js
@@ -1,4 +1,4 @@
-import E from './replayemitter'
+import E, { fromBus, reset } from './replayemitter'
 import * as C from '../utils/consts'
 import { isFunction } from '../utils/types'
 
@@ -30,19 +30,19 @@ export function init (size, errorCallback, bus) {
       } else {
         if (isFunction(window[C.EVENT_BUS_NAMESPACE].hierarchical)) {
           const globalBus = window[C.EVENT_BUS_NAMESPACE]
-          const localBusOld = window[C.EVENT_BUS_NAMESPACE].current
           const localBusNew = bus || new E(size)
           localBusNew.setGlobal(globalBus)
           globalBus.setCurrent(localBusNew)
-          localBusOld.unsetGlobal()
           return localBusNew
         } else {
-          // This will lead to losing all global bus listeners
-          const globalBus = new E(size)
+          // We keep the old global bus' state in the new global bus.
+          const globalBusOld = window[C.EVENT_BUS_NAMESPACE]
+          const globalBusNew = fromBus(globalBusOld)
+          reset(globalBusOld)
           const localBusNew = bus || new E(size)
-          localBusNew.setGlobal(globalBus)
-          globalBus.setCurrent(localBusNew)
-          window[C.EVENT_BUS_NAMESPACE] = globalBus
+          localBusNew.setGlobal(globalBusNew)
+          globalBusNew.setCurrent(localBusNew)
+          window[C.EVENT_BUS_NAMESPACE] = globalBusNew
           return localBusNew
         }
       }

--- a/src/events/bus.js
+++ b/src/events/bus.js
@@ -1,5 +1,6 @@
 import E from './replayemitter'
 import * as C from '../utils/consts'
+import { isFunction } from '../utils/types'
 
 export function local (size) {
   return new E(size)

--- a/src/events/error-pixel.js
+++ b/src/events/error-pixel.js
@@ -73,12 +73,6 @@ export function register (state, callHandler) {
     console.log('handlers.error.register', state, _pixelSender)
     if (window && window[C.EVENT_BUS_NAMESPACE] && isFunction(window[C.EVENT_BUS_NAMESPACE].on)) {
       window[C.EVENT_BUS_NAMESPACE].on(C.ERRORS_PREFIX, _pixelError)
-
-      if (isFunction(window[C.EVENT_BUS_NAMESPACE].off) && isFunction(window[C.EVENT_BUS_NAMESPACE].listen)) {
-        window[C.EVENT_BUS_NAMESPACE].listen(C.LC_SHUTDOWN, function(event) {
-          window[C.EVENT_BUS_NAMESPACE].off(C.ERRORS_PREFIX, _pixelError)
-        })
-      }
     }
     _pixelSender = new PixelSender(state, callHandler)
     _state = state || {}

--- a/src/events/error-pixel.js
+++ b/src/events/error-pixel.js
@@ -70,8 +70,8 @@ function _pixelError (error) {
 export function register (state, callHandler) {
   try {
     console.log('handlers.error.register', state, _pixelSender)
-    if (window && window[C.EVENT_BUS_NAMESPACE] && isFunction(window[C.EVENT_BUS_NAMESPACE].on)) {
-      window[C.EVENT_BUS_NAMESPACE].on(C.ERRORS_PREFIX, _pixelError)
+    if (window && window[C.EVENT_BUS_NAMESPACE] && window[C.EVENT_BUS_NAMESPACE].current && isFunction(window[C.EVENT_BUS_NAMESPACE].current.on)) {
+      window[C.EVENT_BUS_NAMESPACE].current.on(C.ERRORS_PREFIX, _pixelError)
     }
     _pixelSender = new PixelSender(state, callHandler)
     _state = state || {}

--- a/src/events/error-pixel.js
+++ b/src/events/error-pixel.js
@@ -3,6 +3,7 @@ import { StateWrapper } from '../pixel/state'
 import * as page from '../enrichers/page'
 import * as C from '../utils/consts'
 import { isFunction } from '../utils/types'
+import {send} from '../utils/emitter'
 
 let _state = null
 let _pixelSender = null
@@ -72,6 +73,12 @@ export function register (state, callHandler) {
     console.log('handlers.error.register', state, _pixelSender)
     if (window && window[C.EVENT_BUS_NAMESPACE] && isFunction(window[C.EVENT_BUS_NAMESPACE].on)) {
       window[C.EVENT_BUS_NAMESPACE].on(C.ERRORS_PREFIX, _pixelError)
+
+      if (isFunction(window[C.EVENT_BUS_NAMESPACE].off) && isFunction(window[C.EVENT_BUS_NAMESPACE].listen)) {
+        window[C.EVENT_BUS_NAMESPACE].listen(C.LC_SHUTDOWN, function(event) {
+          window[C.EVENT_BUS_NAMESPACE].off(C.ERRORS_PREFIX, _pixelError)
+        })
+      }
     }
     _pixelSender = new PixelSender(state, callHandler)
     _state = state || {}

--- a/src/events/error-pixel.js
+++ b/src/events/error-pixel.js
@@ -3,7 +3,6 @@ import { StateWrapper } from '../pixel/state'
 import * as page from '../enrichers/page'
 import * as C from '../utils/consts'
 import { isFunction } from '../utils/types'
-import {send} from '../utils/emitter'
 
 let _state = null
 let _pixelSender = null

--- a/src/events/replayemitter.js
+++ b/src/events/replayemitter.js
@@ -27,25 +27,6 @@ E.prototype = {
     return this
   },
 
-  last: function (name, callback, ctx) {
-    const self = this
-
-    const eventQueue = this.q[name] || []
-    if (eventQueue.length > 0) {
-      callback.apply(ctx, eventQueue.last)
-
-      return this
-    } else {
-      const listener = function () {
-        self.off(name, listener)
-        callback.apply(ctx, arguments)
-      }
-
-      listener._ = callback
-      return this.on(name, listener, ctx)
-    }
-  },
-
   once: function (name, callback, ctx) {
     const self = this
 

--- a/src/events/replayemitter.js
+++ b/src/events/replayemitter.js
@@ -105,6 +105,11 @@ E.prototype = {
     return this
   },
 
+  unsetGlobal: function () {
+    delete this.global
+    return this
+  },
+
   setCurrent: function (other) {
     this.current = other
     return this

--- a/src/events/replayemitter.js
+++ b/src/events/replayemitter.js
@@ -6,17 +6,14 @@
  * @property {(function)} off
  */
 
-export function fromBus (bus) {
+export function fromBusReset (bus) {
   const e = new E()
   e.size = bus.size
   e.h = bus.h
   e.q = bus.q
-  return e
-}
-
-export function reset (bus) {
   bus.h = {}
   bus.q = {}
+  return e
 }
 
 export default function E (replaySize) {
@@ -116,6 +113,10 @@ E.prototype = {
   setGlobal: function (other) {
     this.global = other
     return this
+  },
+
+  unsetGlobal: function () {
+    delete this.global
   },
 
   setCurrent: function (other) {

--- a/src/events/replayemitter.js
+++ b/src/events/replayemitter.js
@@ -13,6 +13,22 @@ export default function E (replaySize) {
 }
 
 E.prototype = {
+  
+  listen: function (name, callback, ctx) {
+    const listener = function () {
+      self.off(name, listener)
+      callback.apply(ctx, arguments)
+    }
+
+    listener._ = callback
+
+    (this.h[name] || (this.h[name] = [])).push({
+      fn: listener,
+      ctx: ctx
+    })
+    return this
+  },
+
   on: function (name, callback, ctx) {
     (this.h[name] || (this.h[name] = [])).push({
       fn: callback,

--- a/src/events/replayemitter.js
+++ b/src/events/replayemitter.js
@@ -58,7 +58,7 @@ E.prototype = {
     if (this.current) {
       this.current.emitNoForward(name, data)
     }
-    
+
     return this
   },
 

--- a/src/events/replayemitter.js
+++ b/src/events/replayemitter.js
@@ -27,6 +27,25 @@ E.prototype = {
     return this
   },
 
+  last: function (name, callback, ctx) {
+    const self = this
+
+    const eventQueue = this.q[name] || []
+    if (eventQueue.length > 0) {
+      callback.apply(ctx, eventQueue.last)
+
+      return this
+    } else {
+      const listener = function () {
+        self.off(name, listener)
+        callback.apply(ctx, arguments)
+      }
+
+      listener._ = callback
+      return this.on(name, listener, ctx)
+    }
+  },
+
   once: function (name, callback, ctx) {
     const self = this
 

--- a/src/events/replayemitter.js
+++ b/src/events/replayemitter.js
@@ -6,6 +6,19 @@
  * @property {(function)} off
  */
 
+export function fromBus (bus) {
+  const e = new E()
+  e.size = bus.size
+  e.h = bus.h
+  e.q = bus.q
+  return e
+}
+
+export function reset (bus) {
+  bus.h = {}
+  bus.q = {}
+}
+
 export default function E (replaySize) {
   this.size = parseInt(replaySize) || 5
   this.h = {}
@@ -102,11 +115,6 @@ E.prototype = {
 
   setGlobal: function (other) {
     this.global = other
-    return this
-  },
-
-  unsetGlobal: function () {
-    delete this.global
     return this
   },
 

--- a/src/standard-live-connect.js
+++ b/src/standard-live-connect.js
@@ -132,8 +132,7 @@ function _getInitializedLiveConnect (liveConnectConfig) {
  */
 function _standardInitialization (liveConnectConfig, externalStorageHandler, externalCallHandler, localBus) {
   try {
-    eventBus.init()
-    _emitShutdownMessage(liveConnectConfig)
+    eventBus.init(null, null, localBus)
     const callHandler = CallHandler(externalCallHandler)
     const configWithPrivacy = merge(liveConnectConfig, privacyConfig(liveConnectConfig))
     errorHandler.register(configWithPrivacy, callHandler)
@@ -151,12 +150,7 @@ function _standardInitialization (liveConnectConfig, externalStorageHandler, ext
     console.log('LiveConnect.postManagedState', postManagedState)
     const syncContainerData = merge(configWithPrivacy, { peopleVerifiedId: postManagedState.data.peopleVerifiedId })
     const onPixelLoad = () => emitter.send(C.PIXEL_SENT_PREFIX, syncContainerData)
-    const onPixelPreload = () => {
-      if (localBus) {
-        localBus.emit(C.PRELOAD_PIXEL, '0')
-      }
-      emitter.send(C.PRELOAD_PIXEL, '0')
-    }
+    const onPixelPreload = () => emitter.send(C.PRELOAD_PIXEL, '0')
     const pixelClient = new PixelSender(configWithPrivacy, callHandler, onPixelLoad, onPixelPreload)
     const resolver = IdentityResolver(postManagedState.data, storageHandler, callHandler)
     const _configManager = _initializeConfigManager(liveConnectConfig)
@@ -178,10 +172,6 @@ function _standardInitialization (liveConnectConfig, externalStorageHandler, ext
   }
 }
 
-function _emitShutdownMessage (config) {
-  emitter.send(C.LC_SHUTDOWN, config)
-}
-
 function _initializeConfigManager (config) {
   if (window.liQ && window.liQ.configManager) {
     const configManager = window.liQ.configManager
@@ -201,12 +191,12 @@ function _initializeConfigManager (config) {
  * @returns {StandardLiveConnect}
  * @constructor
  */
-export function StandardLiveConnect (liveConnectConfig, externalStorageHandler, externalCallHandler, pixelPreload) {
+export function StandardLiveConnect (liveConnectConfig, externalStorageHandler, externalCallHandler, localBus) {
   console.log('Initializing LiveConnect')
   try {
     const queue = window.liQ || []
     const configuration = (isObject(liveConnectConfig) && liveConnectConfig) || {}
-    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, pixelPreload) || queue)
+    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, localBus) || queue)
     if (isArray(queue)) {
       for (let i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i])

--- a/src/standard-live-connect.js
+++ b/src/standard-live-connect.js
@@ -107,7 +107,7 @@ function _processArgs (args, pixelClient, enrichedState, configManager) {
 function _getInitializedLiveConnect (liveConnectConfig) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (!qualifiedConfig(liveConnectConfig)) {
+      if (qualifiedConfig(window.liQ.config) || !qualifiedConfig(liveConnectConfig)) {
         const mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig)
         if (mismatchedConfig) {
           const error = new Error()

--- a/src/standard-live-connect.js
+++ b/src/standard-live-connect.js
@@ -107,7 +107,8 @@ function _processArgs (args, pixelClient, enrichedState, configManager) {
 function _getInitializedLiveConnect (liveConnectConfig, initializationCallback) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (qualifiedConfig(window.liQ.config) && !initializationCallback) {
+      if ((!qualifiedConfig(liveConnectConfig)) ||
+        (qualifiedConfig(liveConnectConfig) && qualifiedConfig(window.liQ.config) && !initializationCallback)) {
         const mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig)
         if (mismatchedConfig) {
           const error = new Error()

--- a/src/standard-live-connect.js
+++ b/src/standard-live-connect.js
@@ -46,7 +46,7 @@ import { IdentityResolver } from './idex/identity-resolver'
 import { StorageHandler } from './handlers/storage-handler'
 import { CallHandler } from './handlers/call-handler'
 import { StorageStrategy } from './model/storage-strategy'
-import ConfigManager, { hasPriorityOver } from './config/config-manager'
+import ConfigManager, { qualifiedConfig } from './config/config-manager'
 
 const hemStore = {}
 function _pushSingleEvent (event, pixelClient, enrichedState, configManager) {
@@ -104,10 +104,10 @@ function _processArgs (args, pixelClient, enrichedState, configManager) {
  * @return {StandardLiveConnect|null}
  * @private
  */
-function _getInitializedLiveConnect (liveConnectConfig) {
+function _getInitializedLiveConnect (liveConnectConfig, initializationCallback) {
   try {
     if (window && window.liQ && window.liQ.ready) {
-      if (hasPriorityOver(window.liQ.config, liveConnectConfig)) {
+      if (qualifiedConfig(window.liQ.config) && !initializationCallback) {
         const mismatchedConfig = window.liQ.config && _configMatcher(window.liQ.config, liveConnectConfig)
         if (mismatchedConfig) {
           const error = new Error()
@@ -204,7 +204,7 @@ export function StandardLiveConnect (liveConnectConfig, externalStorageHandler, 
   try {
     const queue = window.liQ || []
     const configuration = (isObject(liveConnectConfig) && liveConnectConfig) || {}
-    window && (window.liQ = _getInitializedLiveConnect(configuration) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue)
+    window && (window.liQ = _getInitializedLiveConnect(configuration, initializationCallback) || _standardInitialization(configuration, externalStorageHandler, externalCallHandler, initializationCallback) || queue)
     if (isArray(queue)) {
       for (let i = 0; i < queue.length; i++) {
         window.liQ.push(queue[i])

--- a/src/standard-live-connect.js
+++ b/src/standard-live-connect.js
@@ -155,7 +155,6 @@ function _standardInitialization (liveConnectConfig, externalStorageHandler, ext
     const resolver = IdentityResolver(postManagedState.data, storageHandler, callHandler)
     const _configManager = _initializeConfigManager(liveConnectConfig)
     const _push = (...args) => _processArgs(args, pixelClient, postManagedState, _configManager)
-    _emitSyncContainerData(syncContainerData)
 
     return {
       push: _push,
@@ -171,10 +170,6 @@ function _standardInitialization (liveConnectConfig, externalStorageHandler, ext
     console.error(x)
     emitter.error('LCConstruction', 'Failed to build LC', x)
   }
-}
-
-function _emitSyncContainerData (data) {
-  emitter.send(C.SYNC_CONTAINER_CONFIG, data)
 }
 
 function _initializeConfigManager (config) {

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -2,7 +2,6 @@ export const EVENT_BUS_NAMESPACE = '__li__evt_bus'
 export const ERRORS_PREFIX = 'li_errors'
 export const PIXEL_SENT_PREFIX = 'lips'
 export const PRELOAD_PIXEL = 'pre_lips'
-export const SYNC_CONTAINER_DATA = 'scd'
 
 export const PEOPLE_VERIFIED_LS_ENTRY = '_li_duid'
 

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -2,7 +2,6 @@ export const EVENT_BUS_NAMESPACE = '__li__evt_bus'
 export const ERRORS_PREFIX = 'li_errors'
 export const PIXEL_SENT_PREFIX = 'lips'
 export const PRELOAD_PIXEL = 'pre_lips'
-export const LC_SHUTDOWN = 'LC_SHUTDOWN'
 
 export const PEOPLE_VERIFIED_LS_ENTRY = '_li_duid'
 

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -2,6 +2,7 @@ export const EVENT_BUS_NAMESPACE = '__li__evt_bus'
 export const ERRORS_PREFIX = 'li_errors'
 export const PIXEL_SENT_PREFIX = 'lips'
 export const PRELOAD_PIXEL = 'pre_lips'
+export const SYNC_CONTAINER_DATA = 'scd'
 
 export const PEOPLE_VERIFIED_LS_ENTRY = '_li_duid'
 

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -2,6 +2,7 @@ export const EVENT_BUS_NAMESPACE = '__li__evt_bus'
 export const ERRORS_PREFIX = 'li_errors'
 export const PIXEL_SENT_PREFIX = 'lips'
 export const PRELOAD_PIXEL = 'pre_lips'
+export const LC_SHUTDOWN = 'LC_SHUTDOWN'
 
 export const PEOPLE_VERIFIED_LS_ENTRY = '_li_duid'
 

--- a/src/utils/emitter.js
+++ b/src/utils/emitter.js
@@ -1,7 +1,7 @@
 import * as C from '../utils/consts'
 
 function _emit (prefix, message) {
-  window && window[C.EVENT_BUS_NAMESPACE] && window[C.EVENT_BUS_NAMESPACE].emit(prefix, message)
+  window && window[C.EVENT_BUS_NAMESPACE] && window[C.EVENT_BUS_NAMESPACE].current.emit(prefix, message)
 }
 
 export function send (prefix, message) {

--- a/test/unit/events/error-pixel.spec.js
+++ b/test/unit/events/error-pixel.spec.js
@@ -32,9 +32,9 @@ describe('ErrorPixel', () => {
     stub.restore()
   })
 
-  it('should register itself on the global bus', function () {
+  it('should register itself on the current bus', function () {
     errorPixel.register({ collectorUrl: 'http://localhost' })
-    const errorHandler = windowBus.h
+    const errorHandler = windowBus.current.h
     expect(errorHandler).to.have.key(C.ERRORS_PREFIX)
     expect(errorHandler[C.ERRORS_PREFIX].length).to.be.eql(1)
     expect(errorHandler[C.ERRORS_PREFIX][0].fn.name).to.eql('_pixelError')

--- a/test/unit/standard-live-connect.spec.js
+++ b/test/unit/standard-live-connect.spec.js
@@ -47,7 +47,7 @@ describe('StandardLiveConnect', () => {
   it('should initialise the event bus, and hook the error handler', function () {
     StandardLiveConnect({})
     const windowBus = window[C.EVENT_BUS_NAMESPACE]
-    const errorHandler = windowBus.h
+    const errorHandler = windowBus.current.h
     expect(errorHandler).to.have.key(C.ERRORS_PREFIX)
     expect(errorHandler[C.ERRORS_PREFIX].length).to.be.eql(1)
     expect(errorHandler[C.ERRORS_PREFIX][0].fn.name).to.eql('_pixelError')

--- a/test/unit/standard-live-connect.spec.js
+++ b/test/unit/standard-live-connect.spec.js
@@ -59,12 +59,12 @@ describe('StandardLiveConnect', () => {
     expect(window.liQ.ready).to.be.true()
   })
 
-  it('should expose liQ, emit error for any subsequent initialization with different config', function () {
+  it('should expose liQ, emit error for any subsequent initialization with config without appId', function () {
     StandardLiveConnect({ appId: 'a-00xx' }, storage, calls)
     let liQ = window.liQ
     expect(liQ.ready).to.be.true()
     liQ.push({ event: 'viewProduct', name: 'a-00xx' })
-    StandardLiveConnect({ appId: 'config' }, storage, calls)
+    StandardLiveConnect({ }, storage, calls)
     liQ = window.liQ
     expect(liQ.ready).to.be.true()
     liQ.push({ event: 'viewProduct', name: 'config' })
@@ -211,13 +211,12 @@ describe('StandardLiveConnect', () => {
     expect(params.ae).to.not.eq(undefined)
   })
 
-  it('should emit an error if the pushed value is a config', function () {
-    const lc = StandardLiveConnect({}, storage, calls)
-    lc.push({ config: {} })
-    expect(errorCalls.length).to.eql(1)
-    const params = urlParams(errorCalls[0].src)
-    // I don't want to check the full content here, i'm fine with just being present
-    expect(params.ae).to.not.eq(undefined)
+  it('should store the config in the manager if the pushed value is a config', function () {
+    const lc = StandardLiveConnect({ appId: 'a-00xx' }, storage, calls)
+    lc.push({ config: { appId: 'a-00yy' } })
+    expect(lc.configManager.configs().length).to.eql(2)
+    expect(lc.configManager.configs()[0]).to.eql({ appId: 'a-00xx' })
+    expect(lc.configManager.configs()[1]).to.eql({ appId: 'a-00yy' })
   })
 
   it('should emit an error if the storage and ajax are not provided', function () {


### PR DESCRIPTION
**Current State**
There is the LiveConnect module (in the following text the term module will be used) that we distribute and that is used by third parties like Prebid. There is the LiveConnect version that we  distribute via our CDN (in the following text the term builder will be used).

The module accepts a configuration in its constructor functions. The builder expects a configuration either being provided via window.liQ.push or by setting the global property window.LI.

Currently, when LiveConnect (LC) is initialized multiple times on a page, the configuration that was used for the first initialization will prevail, the other ones will be ignored:

- if the module is initialized using config A and then there is an attempt to initialize it with config B, the module will check if there is an already initialized LC and if so, just return it; [it will also check if the config of the initialized LC deviates from the provided config in appId, collector URL or wrapper name](https://github.com/LiveIntent/live-connect/blob/de67aa6b81eaa6254dd3eb95e5b596fe47847df2/src/standard-live-connect.js#L71) and emit an error if so

- if LC is initialized (either via module or builder) and a config is published via window.liQ.push({config: …}), [this config will be ignored and an error message emitted](https://github.com/LiveIntent/live-connect/blob/de67aa6b81eaa6254dd3eb95e5b596fe47847df2/src/standard-live-connect.js#L55)

**Problem**

We have customers that have LC installed on their websites and have a partnership with ad tech companies that also place LC on these websites. This results, depending on the order in which the scripts are loaded, in a LC being initialized with a configuration that belongs to the ad tech company and not to our customer itself. 

The assumption for this work is that the partners do not provide an appId in their configurations. This leads to losing information in the data sent to LivePixel - e.g. not having the appId or not starting the SyncContainer.

**Goal**

When LC is loaded multiple times with different configurations on the same page, the resulting LC must have the configuration that has an appId, if such a configuration was provided on the page.

**Proposal**
In this proposal the following changes have been made:

The module was adjusted as follows:
- current window.liQ is overwritten when the provided config has higher priority than the current one (the presence of appId is the discriminator for now)
- adjusted the module to collect and expose configs a config that have been submitted via window.liQ push when a LC instance was already running

The builder was adjusted as follows:
- the builder uses a local bus for initialization
- the builder evaluates all available configurations upon its initialization and selects one with the highest priority (the one with the highest priority from the ones known to the currently running LC + window.LI + window.liQ - in that order; if no config with appId is present, select the first one or wait for one to appear)
- the builder provides a callback when calling the module; this callback is called whenever the module overwrites the current window.liQ; it publishes events into privacy topics and starts the SyncContainer if the applied config permits it

**Notes**
With this proposal, the global event bus remains untouched when window.liQ is overwritten. That allows to keep all subscribers and does not overcomplicates the code. However, if the old LC is not garbage collected after the new one has been initialized, we will see one error reported to LivePixel twice. After thinking more about it, it is not a big deal. We can, if we see that it is an issue, identify and remove "internal" topic listeners if required when we overwrite window.liQ.

Also, the SyncContainer may be executed multiple times if there are multiple configs with appId and enabled sync (and no gdpr). This will cause no harm. In case the first initialized LC does not have an appId or has the sync disabled or has gdpr enabled, but the second one has an appId, enabled sync and no gdpr, the sync container will work based on the config of the first LC. In either case, if the sync would be executed according to one of the used configs, it will be executed. 

**TODOs**: 
- [ ] define scenarios with combinations of old/new module and builder, SyncContainer, configurations as well as the times these configurations become available and execute thorough manual tests
- [ ] thorough automated testing

Related PRs:
- https://github.com/LiveIntent/liveconnectbuilder/pull/61
- https://github.com/LiveIntent/synccontainer/pull/31

Author Todo List:

- [ ] Add/adjust tests (if applicable)
- [ ] Build in CI passes
- [ ] Latest master revision is merged into the branch
- [ ] Self-Review
- [ ] Set `Ready For Review` status
