### PR TITLE
Investigate and fix decode urls in Live-connect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "live-connect-js",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "tiny-hashes": "1.0.1"

--- a/src/manager/decisions.js
+++ b/src/manager/decisions.js
@@ -1,4 +1,4 @@
-import { urlParamsWithPredicate } from '../utils/url'
+import { getQueryParameter } from '../utils/url'
 import { trim, isUUID, expiresInDays } from '../utils/types'
 
 const DEFAULT_DECISION_ID_COOKIE_EXPIRES = expiresInDays(30)
@@ -28,8 +28,7 @@ export function resolve (state, storageHandler, eventBus) {
     }
   }
   try {
-    const params = (state.pageUrl && urlParamsWithPredicate(state.pageUrl, (queryName) => queryName === DECISION_ID_QUERY_PARAM_NAME)) || {}
-    const freshDecisions = [].concat(params[DECISION_ID_QUERY_PARAM_NAME] || [])
+    const freshDecisions = [].concat((state.pageUrl && getQueryParameter(state.pageUrl, DECISION_ID_QUERY_PARAM_NAME)) || [])
     const storedDecisions = storageHandler.findSimilarCookies(DECISION_ID_COOKIE_NAMESPACE)
     freshDecisions
       .map(trim)

--- a/src/manager/decisions.js
+++ b/src/manager/decisions.js
@@ -1,4 +1,4 @@
-import { urlParams } from '../utils/url'
+import { urlParamsWithPredicate } from '../utils/url'
 import { trim, isUUID, expiresInDays } from '../utils/types'
 
 const DEFAULT_DECISION_ID_COOKIE_EXPIRES = expiresInDays(30)
@@ -28,7 +28,7 @@ export function resolve (state, storageHandler, eventBus) {
     }
   }
   try {
-    const params = (state.pageUrl && urlParams(state.pageUrl)) || {}
+    const params = (state.pageUrl && urlParamsWithPredicate(state.pageUrl, (queryName) => queryName === DECISION_ID_QUERY_PARAM_NAME)) || {}
     const freshDecisions = [].concat(params[DECISION_ID_QUERY_PARAM_NAME] || [])
     const storedDecisions = storageHandler.findSimilarCookies(DECISION_ID_COOKIE_NAMESPACE)
     freshDecisions

--- a/src/pixel/fiddler.js
+++ b/src/pixel/fiddler.js
@@ -1,4 +1,5 @@
 import { extractEmail } from '../utils/email'
+import { decodeValue } from '../utils/url'
 import { extractHashValue, hashEmail, isHash } from '../utils/hash'
 import { isArray, isObject, safeToString, trim, merge } from '../utils/types'
 
@@ -16,7 +17,7 @@ function _provided (state) {
       const extractedEmail = extractEmail(value)
       const extractedHash = extractHashValue(value)
       if (extractedEmail) {
-        const hashes = hashEmail(decodeURIComponent(extractedEmail))
+        const hashes = hashEmail(decodeValue(extractedEmail))
         return merge({ hashedEmail: [hashes.md5, hashes.sha1, hashes.sha256] }, state)
       } else if (extractedHash && isHash(extractedHash)) {
         return merge({ hashedEmail: [extractedHash.toLowerCase()] }, state)

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -31,7 +31,16 @@ function _convert (v) {
   return _isBoolean(_isNull(_isNum(v)))
 }
 
-function _urlParams (url) {
+function _parseParam (params, key) {
+  if (isArray(params[key])) {
+    params[key] = params[key].map(v => _convert(_decode(`${v}`)))
+  } else {
+    params[key] = _convert(_decode(`${params[key]}`))
+  }
+  return params[key]
+}
+
+function _allParams (url) {
   let questionMarkIndex, queryParams, historyIndex
   const obj = {}
   if (!url || (questionMarkIndex = url.indexOf('?')) === -1 || !(queryParams = url.slice(questionMarkIndex + 1))) {
@@ -52,22 +61,12 @@ function _urlParams (url) {
 }
 
 export function urlParams (url) {
-  const params = _urlParams(url)
-  Object.keys(params).forEach((k) => {
-    if (isArray(params[k])) {
-      params[k] = params[k].map(v => _convert(_decode(`${v}`)))
-    } else {
-      params[k] = _convert(_decode(`${params[k]}`))
-    }
-  })
+  const params = _allParams(url)
+  Object.keys(params).forEach((k) => _parseParam(params, k))
   return params
 }
 
 export function getQueryParameter (url, name) {
-  const params = _urlParams(url)
-  if (isArray(params[name])) {
-    return params[name].map(v => _convert(_decode(`${v}`)))
-  } else {
-    return _convert(_decode(`${params[name]}`))
-  }
+  const params = _allParams(url)
+  return _parseParam(params, name)
 }

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -12,7 +12,7 @@ export const toParams = (tuples) => {
 }
 
 function _decode (s) {
-  return s.indexOf('%') === -1 ? s : decodeURIComponent(s)
+  return s.indexOf('%') === -1 ? s : decodeValue(s)
 }
 
 function _isNum (v) {
@@ -58,6 +58,10 @@ function _allParams (url) {
     }
   })
   return obj
+}
+
+export function decodeValue (v) {
+  return v.replace(/(%[\dA-F]{2})+/gi, decodeURIComponent)
 }
 
 export function urlParams (url) {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -12,7 +12,14 @@ export const toParams = (tuples) => {
 }
 
 function _decode (s) {
-  return s.indexOf('%') === -1 ? s : decodeURIComponent(s)
+  if (s.indexOf('%') === -1) return s
+  else {
+    try {
+      decodeURIComponent(s)
+    } catch (e) {
+      return s
+    }
+  }
 }
 
 function _isNum (v) {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -11,10 +11,6 @@ export const toParams = (tuples) => {
   return acc
 }
 
-function _decode (s) {
-  return s.indexOf('%') === -1 ? s : decodeValue(s)
-}
-
 function _isNum (v) {
   return isNaN(+v) ? v : +v
 }
@@ -34,9 +30,9 @@ function _convert (v) {
 function _parseParam (params, key) {
   if (params[key]) {
     if (isArray(params[key])) {
-      params[key] = params[key].map(v => _convert(_decode(v)))
+      params[key] = params[key].map(v => _convert(decodeValue(v)))
     } else {
-      params[key] = _convert(_decode(params[key]))
+      params[key] = _convert(decodeValue(params[key]))
     }
     return params[key]
   }

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -20,7 +20,11 @@ function _isNum (v) {
 }
 
 function _isNull (v) {
-  return v === 'null' || v === 'undefined' ? null : v
+  return v === 'null' ? null : v
+}
+
+function _isUndefined (v) {
+  return v === 'undefined' ? undefined : v
 }
 
 function _isBoolean (v) {
@@ -28,7 +32,7 @@ function _isBoolean (v) {
 }
 
 function _convert (v) {
-  return _isBoolean(_isNull(_isNum(v)))
+  return _isBoolean(_isNull(_isUndefined(_isNum(v))))
 }
 
 function _parseParam (params, key) {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -58,5 +58,5 @@ export function urlParamsWithPredicate (url, predicate) {
 }
 
 export function urlParams (url) {
-  return urlParamsWithPredicate(url, (p) => true)
+  return urlParamsWithPredicate(url, (name) => true)
 }

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -34,12 +34,12 @@ function _convert (v) {
 function _parseParam (params, key) {
   if (params[key]) {
     if (isArray(params[key])) {
-      params[key] = params[key].map(v => _convert(_decode(`${v}`)))
+      params[key] = params[key].map(v => _convert(_decode(v)))
     } else {
-      params[key] = _convert(_decode(`${params[key]}`))
+      params[key] = _convert(_decode(params[key]))
     }
     return params[key]
-  } else return undefined
+  }
 }
 
 function _allParams (url) {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -20,11 +20,7 @@ function _isNum (v) {
 }
 
 function _isNull (v) {
-  return v === 'null' ? null : v
-}
-
-function _isUndefined (v) {
-  return v === 'undefined' ? undefined : v
+  return v === 'null' || v === 'undefined' ? null : v
 }
 
 function _isBoolean (v) {
@@ -32,16 +28,18 @@ function _isBoolean (v) {
 }
 
 function _convert (v) {
-  return _isBoolean(_isNull(_isUndefined(_isNum(v))))
+  return _isBoolean(_isNull(_isNum(v)))
 }
 
 function _parseParam (params, key) {
-  if (isArray(params[key])) {
-    params[key] = params[key].map(v => _convert(_decode(`${v}`)))
-  } else {
-    params[key] = _convert(_decode(`${params[key]}`))
-  }
-  return params[key]
+  if (params[key]) {
+    if (isArray(params[key])) {
+      params[key] = params[key].map(v => _convert(_decode(`${v}`)))
+    } else {
+      params[key] = _convert(_decode(`${params[key]}`))
+    }
+    return params[key]
+  } else return undefined
 }
 
 function _allParams (url) {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -15,7 +15,7 @@ function _decode (s) {
   if (s.indexOf('%') === -1) return s
   else {
     try {
-      decodeURIComponent(s)
+      return decodeURIComponent(s)
     } catch (e) {
       return s
     }

--- a/test/unit/utils/url.spec.js
+++ b/test/unit/utils/url.spec.js
@@ -54,6 +54,7 @@ describe('UrlUtils', () => {
     expect(params.utm_source).to.eq('google')
     expect(params.utm_campaign).to.eq('Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7')
     expect(params.utm_content).to.eq('Diamonds%3A_Price')
+    expect(params.utm_term).to.eq('%E4%B8%80+%E5%85%8B%E6%')
     expect(params.name).to.eq(7)
   })
 })

--- a/test/unit/utils/url.spec.js
+++ b/test/unit/utils/url.spec.js
@@ -12,8 +12,8 @@ const elements = [
   'number=1234',
   'numeric=1234',
   'number=22.55',
-  'null=null',
-  'undefined=undefined',
+  'null=undefined',
+  'undefined=null',
   'novalue',
   'array=c'
 ].join('&')
@@ -26,12 +26,9 @@ describe('UrlUtils', () => {
     expect(params.numeric).to.eq(1234)
   })
 
-  it('should ignore nulls', () => {
+  it('should ignore undefined & nulls', () => {
     expect(params.null).to.eq(null)
-  })
-
-  it('should ignore undefined', () => {
-    expect(params.undefined).to.eq(undefined)
+    expect(params.undefined).to.eq(null)
   })
 
   it('should parse boolean values', () => {
@@ -51,7 +48,16 @@ describe('UrlUtils', () => {
   })
 
   it('getQueryParameter should not fail when there are some invalid query values that are not selected', () => {
-    const name = getQueryParameter('https://www.bluenile.com/hk/zh/diamonds?gclid=CjwKCAiAh9q&click_id=12&utm_source=google&utm_campaign=Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7&utm_content=Diamonds%3A_Price&utm_term=%E4%B8%80+%E5%85%8B%E6%&name=%37', 'name')
+    const name = getQueryParameter('https://localhost:80/hk/zh/diamonds?gclid=CjwKCAiAh9q&click_id=12&utm_source=google&utm_campaign=Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7&utm_content=Diamonds%3A_Price&utm_term=%E4%B8%80+%E5%85%8B%E6%&name=%37', 'name')
     expect(name).to.eq(7)
+  })
+
+  it('getQueryParameter returns undefined for a non defined queryName', () => {
+    const name = getQueryParameter('https://localhost:80?bla=123', 'name')
+    expect(name).to.be.undefined()
+  })
+  it('getQueryParameter returns null for a query with undefined value', () => {
+    const name = getQueryParameter('https://localhost:80?bla=123&name=undefined', 'name')
+    expect(name).to.be.eq(null)
   })
 })

--- a/test/unit/utils/url.spec.js
+++ b/test/unit/utils/url.spec.js
@@ -12,8 +12,8 @@ const elements = [
   'number=1234',
   'numeric=1234',
   'number=22.55',
-  'null=undefined',
-  'undefined=null',
+  'null=null',
+  'undefined=undefined',
   'novalue',
   'array=c'
 ].join('&')
@@ -26,9 +26,12 @@ describe('UrlUtils', () => {
     expect(params.numeric).to.eq(1234)
   })
 
-  it('should ignore undefined & nulls', () => {
+  it('should ignore nulls', () => {
     expect(params.null).to.eq(null)
-    expect(params.undefined).to.eq(null)
+  })
+
+  it('should ignore undefined', () => {
+    expect(params.undefined).to.eq(undefined)
   })
 
   it('should parse boolean values', () => {

--- a/test/unit/utils/url.spec.js
+++ b/test/unit/utils/url.spec.js
@@ -1,5 +1,5 @@
 import { expect, use } from 'chai'
-import { urlParams } from '../../../src/utils/url'
+import { urlParams, urlParamsWithPredicate } from '../../../src/utils/url'
 import dirtyChai from 'dirty-chai'
 
 use(dirtyChai)
@@ -47,11 +47,13 @@ describe('UrlUtils', () => {
     expect(params.array).to.deep.equal(['a', 'b', 'c'])
   })
 
-  it('should not fail when the url could not be decoded', () => {
-    const params = urlParams('https://www.bluenile.com/hk/zh/diamonds?gclid=CjwKCAiAh9q&click_id=12&utm_source=google&utm_medium=text&utm_campaign=Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7&utm_content=Diamonds%3A_Price&utm_term=%E4%B8%80+%E5%85%8B%E6%')
+  it('should not fail when there are some invalid query values that are not part of the predicate', () => {
+    const params = urlParamsWithPredicate('https://www.bluenile.com/hk/zh/diamonds?gclid=CjwKCAiAh9q&click_id=12&utm_source=google&utm_campaign=Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7&utm_content=Diamonds%3A_Price&utm_term=%E4%B8%80+%E5%85%8B%E6%&name=%37', (name) => name === 'name')
     expect(params.gclid).to.eq('CjwKCAiAh9q')
     expect(params.click_id).to.eq(12)
     expect(params.utm_source).to.eq('google')
     expect(params.utm_campaign).to.eq('Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7')
+    expect(params.utm_content).to.eq('Diamonds%3A_Price')
+    expect(params.name).to.eq(7)
   })
 })

--- a/test/unit/utils/url.spec.js
+++ b/test/unit/utils/url.spec.js
@@ -1,5 +1,5 @@
 import { expect, use } from 'chai'
-import { urlParams, urlParamsWithPredicate } from '../../../src/utils/url'
+import { urlParams, getQueryParameter } from '../../../src/utils/url'
 import dirtyChai from 'dirty-chai'
 
 use(dirtyChai)
@@ -47,14 +47,8 @@ describe('UrlUtils', () => {
     expect(params.array).to.deep.equal(['a', 'b', 'c'])
   })
 
-  it('should not fail when there are some invalid query values that are not part of the predicate', () => {
-    const params = urlParamsWithPredicate('https://www.bluenile.com/hk/zh/diamonds?gclid=CjwKCAiAh9q&click_id=12&utm_source=google&utm_campaign=Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7&utm_content=Diamonds%3A_Price&utm_term=%E4%B8%80+%E5%85%8B%E6%&name=%37', (name) => name === 'name')
-    expect(params.gclid).to.eq('CjwKCAiAh9q')
-    expect(params.click_id).to.eq(12)
-    expect(params.utm_source).to.eq('google')
-    expect(params.utm_campaign).to.eq('Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7')
-    expect(params.utm_content).to.eq('Diamonds%3A_Price')
-    expect(params.utm_term).to.eq('%E4%B8%80+%E5%85%8B%E6%')
-    expect(params.name).to.eq(7)
+  it('getQueryParameter should not fail when there are some invalid query values that are not selected', () => {
+    const name = getQueryParameter('https://www.bluenile.com/hk/zh/diamonds?gclid=CjwKCAiAh9q&click_id=12&utm_source=google&utm_campaign=Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7&utm_content=Diamonds%3A_Price&utm_term=%E4%B8%80+%E5%85%8B%E6%&name=%37', 'name')
+    expect(name).to.eq(7)
   })
 })

--- a/test/unit/utils/url.spec.js
+++ b/test/unit/utils/url.spec.js
@@ -46,4 +46,12 @@ describe('UrlUtils', () => {
   it('should parse array values', () => {
     expect(params.array).to.deep.equal(['a', 'b', 'c'])
   })
+
+  it('should not fail when the url could not be decoded', () => {
+    const params = urlParams('https://www.bluenile.com/hk/zh/diamonds?gclid=CjwKCAiAh9q&click_id=12&utm_source=google&utm_medium=text&utm_campaign=Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7&utm_content=Diamonds%3A_Price&utm_term=%E4%B8%80+%E5%85%8B%E6%')
+    expect(params.gclid).to.eq('CjwKCAiAh9q')
+    expect(params.click_id).to.eq(12)
+    expect(params.utm_source).to.eq('google')
+    expect(params.utm_campaign).to.eq('Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7')
+  })
 })


### PR DESCRIPTION
## [CM-630](https://liveintent.atlassian.net/browse/CM-630)
The logs: [here](https://search-streams-production-ggatbwema5ghxbi5aqpcvkcile.us-east-1.es.amazonaws.com/_plugin/kibana/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-4h,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:details.trackerVersion,negate:!f,params:(query:v2.5.1),type:phrase),query:(match_phrase:(details.trackerVersion:v2.5.1))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!f,params:(query:DecisionsResolve),type:phrase),query:(match_phrase:(errorDetails.name:DecisionsResolve)))),index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,interval:auto,query:(language:kuery,query:''),sort:!()))
shows errors: Error while managing decision ids: URIError: URI malformed

And when you look to the `requestDetails.originUrl` they contain `%` even they aren't encoded. And in this case the url doesn't need to be decoded.

Example:

open this page: 

[https://www.bluenile.com/hk/zh/diamonds?gclid=CjwKCAiAh9qdBhAOEiwAvxIok639kgT6vvuWV9-EkJL8w9K70leaL5ARCmhvkWxBerVNkpI3nOBiaxoC8soQAvD_BwE&click_id=384939136&utm_source=google&utm_medium=text&utm_campaign=Google_%7C_GC_%7C_HK_%7C_Traditional_Chinese_%7C_Text_%7C_Non-Brand_%7C_ENG_%7C_NA_%7C_Engagement_%7&utm_content=Diamonds%3A_Price&utm_term=%E4%B8%80+%E5%85%8B%E6%8B%89+%E9%91%BD%E7%9F%B3+%E5%83%B9%E6%A0%BC](https://www.bluenile.com/hk/zh/diamonds?gclid=CjwKCAiAh9qdBhAOEiwAvxIok639kgT6vvuWV9-EkJL8w9K70leaL5ARCmhvkWxBerVNkpI3nOBiaxoC8soQAvD_BwE&click_id=384939136&utm_source=google&utm_medium=text&utm_campaign=Google_%257C_GC_%257C_HK_%257C_Traditional_Chinese_%257C_Text_%257C_Non-Brand_%257C_ENG_%257C_NA_%257C_Engagement_%257&utm_content=Diamonds%253A_Price&utm_term=%25E4%25B8%2580+%25E5%2585%258B%25E6%258B%2589+%25E9%2591%25BD%25E7%259F%25B3+%25E5%2583%25B9%25E6%25A0%25BC)

We get an error:

```
Error while managing decision ids
URIError: URI malformed
    at decodeURIComponent (<anonymous>)
    at he (https://b-code.liadm.com/a-0389.min.js:1:9458...
```

The reason is when the decision calls urlParams it tries to decode the url because it contains `%` on its values even it's not properly encoded: https://github.com/LiveIntent/live-connect/blob/master/src/utils/url.js#L15

Author Todo List:

- [x] Add/adjust tests (if applicable)
- [x] Build in CI passes
- [x] Latest master revision is merged into the branch
- [x] Self-Review
- [x] Set `Ready For Review` status


[CM-630]: https://liveintent.atlassian.net/browse/CM-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ