### PR TITLE
Add bakersJson in the error message

### DIFF
--- a/src/pixel/sender.js
+++ b/src/pixel/sender.js
@@ -42,7 +42,7 @@ export function PixelSender (liveConnectConfig, calls, eventBus, onload, presend
         for (let i = 0; i < bakers.length; i++) calls.pixelGet(`${bakers[i]}?dtstmp=${utcMillis()}`)
       }
     } catch (e) {
-      eventBus.emitErrorWithMessage('CallBakers', 'Error while calling bakers', e)
+      eventBus.emitErrorWithMessage('CallBakers', `Error while calling bakers with ${bakersJson}`, e)
     }
   }
 


### PR DESCRIPTION
There is [this](https://search-streams-production-ggatbwema5ghxbi5aqpcvkcile.us-east-1.es.amazonaws.com/_plugin/kibana/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-4h,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!t,params:(query:StrayConfig),type:phrase),query:(match_phrase:(errorDetails.name:StrayConfig))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!t,params:(query:LCDuplication),type:phrase),query:(match_phrase:(errorDetails.name:LCDuplication))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!t,params:(query:AjaxFailed),type:phrase),query:(match_phrase:(errorDetails.name:AjaxFailed))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!t,params:(query:LSCheckError),type:phrase),query:(match_phrase:(errorDetails.name:LSCheckError))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!t,params:(query:CookieReadError),type:phrase),query:(match_phrase:(errorDetails.name:CookieReadError))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!t,params:(query:CookieFindSimilarInJar),type:phrase),query:(match_phrase:(errorDetails.name:CookieFindSimilarInJar))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!t,params:(query:IdentifiersResolve),type:phrase),query:(match_phrase:(errorDetails.name:IdentifiersResolve))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!t,params:(query:SyncContainerInit),type:phrase),query:(match_phrase:(errorDetails.name:SyncContainerInit))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!t,params:(query:SyncContainerHandleMessage),type:phrase),query:(match_phrase:(errorDetails.name:SyncContainerHandleMessage))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!t,params:(query:IdentifiersEnricher),type:phrase),query:(match_phrase:(errorDetails.name:IdentifiersEnricher))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!t,params:(query:CookieLsGetOrAdd),type:phrase),query:(match_phrase:(errorDetails.name:CookieLsGetOrAdd))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,key:errorDetails.name,negate:!f,params:(query:CallBakers),type:phrase),query:(match_phrase:(errorDetails.name:CallBakers)))),index:afb18c50-a95e-11ea-b7d9-89ab4e3c16e1,interval:auto,query:(language:kuery,query:''),sort:!())) error.
```
CallBakers
SyntaxError: Unexpected end of JSON input
    at Object.parse (<anonymous>) 
```
It could be either because the server closed the socket or we receive a wrong format response from livePixel.

Author Todo List:

- [ ] Add/adjust tests (if applicable)
- [ ] Build in CI passes
- [ ] Latest master revision is merged into the branch
- [ ] Self-Review
- [ ] Set `Ready For Review` status
