### PR TITLE
CM-714 - Do not attach LC to window if no globalVarName is provided

### DIFF
--- a/CONFIGURATION_OPTIONS.md
+++ b/CONFIGURATION_OPTIONS.md
@@ -223,9 +223,9 @@ Example:
 ```
 
 ##### `globalVarName` [Optional]
+**Usage of this parameter is discouraged and it will be deprecated in a future version of this library.** This parameter allows to define the name for the LiveConnect instance that is attached to the window object. If none is provided, Liveconnect will not be attached to the window object. 
 
-This parameter allows to define the name for the Live Connect instance that is attached to the window object, by default: `liQ`.
-For example `globalVarName: "liQ2"` will make the instance name `window.liQ2` instead of `window.liQ`.
+For example `globalVarName: "liQ2"` will make the instance name `window.liQ2`. 
 
 Example:
 ```javascript

--- a/CONFIGURATION_OPTIONS.md
+++ b/CONFIGURATION_OPTIONS.md
@@ -223,7 +223,7 @@ Example:
 ```
 
 ##### `globalVarName` [Optional]
-**Usage of this parameter is discouraged and it will be deprecated in a future version of this library.** This parameter allows to define the name for the LiveConnect instance that is attached to the window object. If none is provided, Liveconnect will not be attached to the window object. 
+**Usage of this parameter is discouraged and it will be deprecated in a future version of this module.** This parameter allows to define the name for the LiveConnect instance that is attached to the window object. If none is provided, Liveconnect will not be attached to the window object. 
 
 For example `globalVarName: "liQ2"` will make the instance name `window.liQ2`. 
 

--- a/README.md
+++ b/README.md
@@ -136,21 +136,21 @@ The `enrichers` folder contains code responsible for extracting specific informa
 `enrichers/identifiers.js` is responsible for reading the `identifiersToResolve` configuration parameter to read any additional identifiers that customers want to share with us.
 
 ## Messaging between components via EventBus
-LiveConnect exposes an object on the instance level (`window[globalVarName].eventBus`, where `globalVarName` is the value found in the configuration or `liQ` if none is provided) which is responsible for communicating various information based on different fields of interests.
+LiveConnect exposes an object via the field `eventBus` on the LiveConnect instance which is responsible for communicating various information based on different fields of interests.
 For example, there are three topics which anyone can hook to, and receive information about:
 - errors, on the `li_errors` topic
 - whenever the pixel is sent successfully, the `lips` topic will emit that information
 - just before the pixel is sent, `pre_lips` topic will contain the information about it.
 
-The following snippets can be used to hook up to one of the topics and receive events as they happen.
+The following snippets can be used to hook up to one of the topics and receive events as they happen. Hre, `lc` is a reference to a LiveConnect instance.
 ```javascript
 const lipsLogger = (message) => { console.info('Received a lips message, will continue receiving them', message) }
-window[globalVarName].eventBus.on('lips', lipsLogger)
+lc.eventBus.on('lips', lipsLogger)
 ```
 or
 ```javascript
 const lipsLogger = (message) => { console.info('Received a lips message once, i will self destruct now.', message) }
-window[globalVarName].eventBus.once('lips', lipsLogger)
+lc.eventBus.once('lips', lipsLogger)
 ```
 
 There are a two ways this can be achieved:
@@ -165,7 +165,7 @@ Vital logic is wrapped in try catch blocks, and where it makes sense, the error 
 To start listening to the topic, one can simply implement their own logic. For example, if logging the messages is of interest, the following snippet can be used:
 ```javascript
 const logger = (message) => {console.error('Error message received on the event bus', message)}
-window[globalVarName].eventBus.on('li_errors', logger)
+lc.eventBus.on('li_errors', logger)
 ```
 ## Receiving errors on the collector
 LiveConnect has a handler called `handlers/error-pixel.js` which is subscribed on the `li_errors` topic, and wraps the exceptions into the following format:

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ For example, there are three topics which anyone can hook to, and receive inform
 - whenever the pixel is sent successfully, the `lips` topic will emit that information
 - just before the pixel is sent, `pre_lips` topic will contain the information about it.
 
-The following snippets can be used to hook up to one of the topics and receive events as they happen. Hre, `lc` is a reference to a LiveConnect instance.
+The following snippets can be used to hook up to one of the topics and receive events as they happen. Here, `lc` is a reference to a LiveConnect instance.
 ```javascript
 const lipsLogger = (message) => { console.info('Received a lips message, will continue receiving them', message) }
 lc.eventBus.on('lips', lipsLogger)

--- a/src/initializer.ts
+++ b/src/initializer.ts
@@ -2,13 +2,11 @@ import { StandardLiveConnect } from './standard-live-connect'
 import { MinimalLiveConnect } from './minimal-live-connect'
 import { CallHandler, StorageHandler, isObject } from 'live-connect-common'
 import { EventBus, ILiveConnect, LiveConnectConfig } from './types'
-
-import { EVENT_BUS_NAMESPACE } from './utils/consts'
-import { GlobalEventBus } from './events/event-bus'
+import { LocalEventBus } from './events/event-bus'
 
 export function LiveConnect(liveConnectConfig: LiveConnectConfig, externalStorageHandler: StorageHandler, externalCallHandler: CallHandler, mode: string, externalEventBus?: EventBus): ILiveConnect | null {
   const minimalMode = mode === 'minimal' || process.env.LiveConnectMode === 'minimal'
-  const bus = externalEventBus || GlobalEventBus(EVENT_BUS_NAMESPACE, 5, err => console.error(err))
+  const bus = externalEventBus || LocalEventBus()
   const configuration = (isObject(liveConnectConfig) && liveConnectConfig) || {}
   const initializationFunction = minimalMode ? MinimalLiveConnect : StandardLiveConnect
   return initializationFunction(configuration, externalStorageHandler, externalCallHandler, bus)

--- a/src/minimal-live-connect.ts
+++ b/src/minimal-live-connect.ts
@@ -48,6 +48,19 @@ function _initializeWithGlobalName(liveConnectConfig: LiveConnectConfig, externa
   return _minimalInitialization(liveConnectConfig, externalStorageHandler, externalCallHandler, eventBus, push)
 }
 
+function _appendToLiQInstances(lc: ILiveConnect): void {
+  window.liQ_instances = window.liQ_instances || []
+
+  const globalVarName = lc.config.globalVarName
+  if (globalVarName) {
+    if (window.liQ_instances.filter(i => i.config.globalVarName === globalVarName).length === 0) {
+      window.liQ_instances.push(lc)
+    }
+  } else {
+    window.liQ_instances.push(lc)
+  }
+}
+
 export function MinimalLiveConnect(liveConnectConfig: LiveConnectConfig, externalStorageHandler: ReadOnlyStorageHandler, externalCallHandler: CallHandler, externalEventBus?: EventBus): ILiveConnect {
   try {
     const configuration = (isObject(liveConnectConfig) && liveConnectConfig) || {}
@@ -57,15 +70,7 @@ export function MinimalLiveConnect(liveConnectConfig: LiveConnectConfig, externa
       _initializeWithGlobalName(configuration, externalStorageHandler, externalCallHandler, eventBus) :
       _initializeWithoutGlobalName(configuration, externalStorageHandler, externalCallHandler, eventBus)
     
-    window.liQ_instances = window.liQ_instances || []
-    if (configuration.globalVarName) {
-      if (window.liQ_instances.filter(i => i.config.globalVarName === configuration.globalVarName).length === 0) {
-        window.liQ_instances.push(lc)
-      }
-    } else {
-      window.liQ_instances.push(lc)
-    }
-
+    _appendToLiQInstances(lc)
     return lc
   } catch (x) {
     console.error(x)

--- a/src/minimal-live-connect.ts
+++ b/src/minimal-live-connect.ts
@@ -60,13 +60,12 @@ function _initializeWithGlobalName(liveConnectConfig: LiveConnectConfig, externa
 export function MinimalLiveConnect(liveConnectConfig: LiveConnectConfig, externalStorageHandler: ReadOnlyStorageHandler, externalCallHandler: CallHandler, externalEventBus?: EventBus): ILiveConnect {
   const configuration = (isObject(liveConnectConfig) && liveConnectConfig) || {}
   const eventBus = externalEventBus || LocalEventBus()
-  let lc
   try {
-    lc = configuration.globalVarName ?
+    return configuration.globalVarName ?
       _initializeWithGlobalName(configuration, externalStorageHandler, externalCallHandler, eventBus) :
       _initializeWithoutGlobalName(configuration, externalStorageHandler, externalCallHandler, eventBus)
   } catch (x) {
     console.error(x)
   }
-  return lc
+  return {}
 }

--- a/src/standard-live-connect.ts
+++ b/src/standard-live-connect.ts
@@ -159,7 +159,7 @@ export function StandardLiveConnect (liveConnectConfig: LiveConnectConfig, exter
 
     return lc
   } catch (e) {
-    console.errore(e)
+    console.error(e)
     eventBus.emitErrorWithMessage('LCConstruction', 'Failed to build LC', e)
   }
   return configuration.globalVarName ? window[configuration.globalVarName] : undefined

--- a/src/standard-live-connect.ts
+++ b/src/standard-live-connect.ts
@@ -159,7 +159,7 @@ export function StandardLiveConnect (liveConnectConfig: LiveConnectConfig, exter
 
     return lc
   } catch (e) {
-    console.error(x)
+    console.errore(e)
     eventBus.emitErrorWithMessage('LCConstruction', 'Failed to build LC', e)
   }
   return configuration.globalVarName ? window[configuration.globalVarName] : undefined

--- a/src/standard-live-connect.ts
+++ b/src/standard-live-connect.ts
@@ -137,25 +137,28 @@ function _initializeWithGlobalName(liveConnectConfig: LiveConnectConfig, externa
   return lc
 }
 
+function _appendToLiQInstances(lc: ILiveConnect): void {
+  window.liQ_instances = window.liQ_instances || []
+  const globalVarName = lc.config.globalVarName
+  if (globalVarName) {
+    if (window.liQ_instances.filter(i => i.config.globalVarName === globalVarName).length === 0) {
+      window.liQ_instances.push(lc)
+    }
+  } else {
+    window.liQ_instances.push(lc)
+  }
+}
+
 export function StandardLiveConnect (liveConnectConfig: LiveConnectConfig, externalStorageHandler: ExternalStorageHandler, externalCallHandler: ExternalCallHandler, externalEventBus?: EventBus): ILiveConnect {
   const configuration = (isObject(liveConnectConfig) && liveConnectConfig) || {}
   const eventBus = externalEventBus || LocalEventBus()
 
   try {
     const lc = configuration.globalVarName ? 
-          _initializeWithGlobalName(liveConnectConfig, externalStorageHandler, externalCallHandler, eventBus) :
-          _initializeWithoutGlobalName(liveConnectConfig, externalStorageHandler, externalCallHandler, eventBus) 
+          _initializeWithGlobalName(configuration, externalStorageHandler, externalCallHandler, eventBus) :
+          _initializeWithoutGlobalName(configuration, externalStorageHandler, externalCallHandler, eventBus) 
 
-    window.liQ_instances = window.liQ_instances || []
-
-    if (configuration.globalVarName) {
-      if (window.liQ_instances.filter(i => i.config.globalVarName === configuration.globalVarName).length === 0) {
-        window.liQ_instances.push(lc)
-      }
-    } else {
-      window.liQ_instances.push(lc)
-    }
-
+    _appendToLiQInstances(lc)
     return lc
   } catch (e) {
     console.error(e)

--- a/src/standard-live-connect.ts
+++ b/src/standard-live-connect.ts
@@ -132,9 +132,8 @@ function _initializeWithGlobalName(liveConnectConfig: LiveConnectConfig, externa
       lc.push(queue[i])
     }
   }
-
-  window[liveConnectConfig.globalVarName] = lc
   
+  window[liveConnectConfig.globalVarName] = lc
   return lc
 }
 

--- a/src/standard-live-connect.ts
+++ b/src/standard-live-connect.ts
@@ -133,7 +133,7 @@ function _initializeWithGlobalName(liveConnectConfig: LiveConnectConfig, externa
     }
   }
 
-  window[configuration.globalVarName] = lc
+  window[liveConnectConfig.globalVarName] = lc
   
   return lc
 }

--- a/test/unit/minimal-live-connect.spec.ts
+++ b/test/unit/minimal-live-connect.spec.ts
@@ -68,7 +68,7 @@ describe('MinimalLiveConnect', () => {
     expect(window.liQ).to.not.be.undefined()
   })
 
-  it('should only add liQ_intances to the window object via the initializer', function () {
+  it('should only add liQ_instances to the window object via the initializer', function () {
     const exisitingKeys = Object.keys(window)
     LiveConnect({}, storage, calls, 'minimal')
     const keysAfterInit = Object.keys(window)

--- a/test/unit/minimal-live-connect.spec.ts
+++ b/test/unit/minimal-live-connect.spec.ts
@@ -54,7 +54,7 @@ describe('MinimalLiveConnect', () => {
     expect(window.liQ_instances).to.not.be.undefined()
   })
 
-  it('should only add liQ_intances to the window object', function () {
+  it('should only add liQ_instances to the window object', function () {
     const exisitingKeys = Object.keys(window)
     MinimalLiveConnect({}, storage, calls)
     const keysAfterInit = Object.keys(window)

--- a/test/unit/minimal-live-connect.spec.ts
+++ b/test/unit/minimal-live-connect.spec.ts
@@ -46,7 +46,7 @@ describe('MinimalLiveConnect', () => {
     })
   })
 
-  it('should expose liQ', function () {
+  it('should expose liQ and liQ_instances', function () {
     expect(window.liQ).to.be.undefined()
     expect(window.liQ_instances).to.be.undefined()
     MinimalLiveConnect({ globalVarName: 'liQ' }, storage, calls)
@@ -96,7 +96,6 @@ describe('MinimalLiveConnect', () => {
   it('should accept a single event and put it in the queue via the initializer', function () {
     const lc = LiveConnect({ globalVarName: 'liQ' }, storage, calls, 'minimal')
     lc.push({ event: 'some' })
-    console.log(window.liQ)
     expect(window.liQ.length).to.eql(1)
   })
 
@@ -108,7 +107,6 @@ describe('MinimalLiveConnect', () => {
   it('should accept firing an event and put it in the queue', function () {
     const lc = MinimalLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     lc.fire()
-    console.log(window.liQ)
     expect(window.liQ.length).to.eql(1)
   })
 

--- a/test/unit/minimal-live-connect.spec.ts
+++ b/test/unit/minimal-live-connect.spec.ts
@@ -48,45 +48,78 @@ describe('MinimalLiveConnect', () => {
 
   it('should expose liQ', function () {
     expect(window.liQ).to.be.undefined()
-    MinimalLiveConnect({}, storage, calls)
+    expect(window.liQ_instances).to.be.undefined()
+    MinimalLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     expect(window.liQ).to.not.be.undefined()
+    expect(window.liQ_instances).to.not.be.undefined()
+  })
+
+  it('should only add liQ_intances to the window object', function () {
+    const exisitingKeys = Object.keys(window)
+    MinimalLiveConnect({}, storage, calls)
+    const keysAfterInit = Object.keys(window)
+    const constNewKeys = keysAfterInit.filter(v => !exisitingKeys.includes(v))
+    expect(constNewKeys).to.be.eql(['liQ_instances'])
   })
 
   it('should expose liQ via the initializer', function () {
     expect(window.liQ).to.be.undefined()
-    LiveConnect({}, storage, calls, 'minimal')
+    LiveConnect({ globalVarName: 'liQ' }, storage, calls, 'minimal')
     expect(window.liQ).to.not.be.undefined()
-    expect(window[EVENT_BUS_NAMESPACE]).to.not.be.undefined()
+  })
+
+  it('should only add liQ_intances to the window object via the initializer', function () {
+    const exisitingKeys = Object.keys(window)
+    LiveConnect({}, storage, calls, 'minimal')
+    const keysAfterInit = Object.keys(window)
+    const constNewKeys = keysAfterInit.filter(v => !exisitingKeys.includes(v))
+    expect(constNewKeys).to.be.eql(['liQ_instances'])
+  })
+
+  it('should accept a single event', function () {
+    const lc = MinimalLiveConnect({}, storage, calls)
+    lc.push({ event: 'some' })
   })
 
   it('should accept a single event and put it in the queue', function () {
-    const lc = MinimalLiveConnect({}, storage, calls)
+    const lc = MinimalLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     lc.push({ event: 'some' })
     console.log(window.liQ)
     expect(window.liQ.length).to.eql(1)
+  })
+
+  it('should accept a single event via the initializer', function () {
+    const lc = LiveConnect({}, storage, calls, 'minimal')
+    lc.push({ event: 'some' })
   })
 
   it('should accept a single event and put it in the queue via the initializer', function () {
-    const lc = LiveConnect({}, storage, calls, 'minimal')
+    const lc = LiveConnect({ globalVarName: 'liQ' }, storage, calls, 'minimal')
     lc.push({ event: 'some' })
     console.log(window.liQ)
     expect(window.liQ.length).to.eql(1)
-    expect(window[EVENT_BUS_NAMESPACE]).to.not.be.undefined()
+  })
+
+  it('should accept firing an event', function () {
+    const lc = MinimalLiveConnect({}, storage, calls)
+    lc.fire()
   })
 
   it('should accept firing an event and put it in the queue', function () {
-    const lc = MinimalLiveConnect({}, storage, calls)
+    const lc = MinimalLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     lc.fire()
     console.log(window.liQ)
     expect(window.liQ.length).to.eql(1)
   })
 
-  it('should accept firing an event and put it in the queue via the initializer', function () {
+  it('should accept firing an event via the initializer', function () {
     const lc = LiveConnect({}, storage, calls, 'minimal')
     lc.fire()
-    console.log(window.liQ)
-    expect(window.liQ.length).to.eql(1)
-    expect(window[EVENT_BUS_NAMESPACE]).to.not.be.undefined()
+  })
+
+  it('should accept firing an event and put it in the queue via the initializer', function () {
+    const lc = LiveConnect({ globalVarName: 'liQ' }, storage, calls, 'minimal')
+    lc.fire()
   })
 
   it('should return the resolution Url', function () {

--- a/test/unit/standard-live-connect.spec.ts
+++ b/test/unit/standard-live-connect.spec.ts
@@ -51,7 +51,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should initialise the event bus, and hook the error handler', function () {
-    StandardLiveConnect({})
+    StandardLiveConnect({ globalVarName: 'liQ' })
     const eventBus = window.liQ.eventBus
     const errorHandler = eventBus.h
     expect(errorHandler).to.have.key(ERRORS_CHANNEL)
@@ -60,7 +60,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should initialise the event bus, and hook the error handler via the initializer', function () {
-    LiveConnect({})
+    LiveConnect({ globalVarName: 'liQ' })
     const eventBus = window.liQ.eventBus
     const errorHandler = eventBus.h
     expect(errorHandler).to.have.key(ERRORS_CHANNEL)
@@ -70,16 +70,16 @@ describe('StandardLiveConnect', () => {
   })
   it('should expose liQ', function () {
     expect(window.liQ).to.be.undefined()
-    StandardLiveConnect({}, storage, calls)
+    StandardLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     expect(window.liQ.ready).to.be.true()
   })
 
   it('should expose liQ, emit error for any subsequent initialization with different config', function () {
-    StandardLiveConnect({ appId: 'a-00xx' }, storage, calls)
+    StandardLiveConnect({ globalVarName: 'liQ', appId: 'a-00xx' }, storage, calls)
     let liQ = window.liQ
     expect(liQ.ready).to.be.true()
     liQ.push({ event: 'viewProduct', name: 'a-00xx' })
-    StandardLiveConnect({ appId: 'config' }, storage, calls)
+    StandardLiveConnect({ globalVarName: 'liQ', appId: 'config' }, storage, calls)
     liQ = window.liQ
     expect(liQ.ready).to.be.true()
     liQ.push({ event: 'viewProduct', name: 'config' })
@@ -103,7 +103,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should expose liQ, and not emit error when the config has not changed', function () {
-    StandardLiveConnect({ appId: 'a-00xx' }, storage, calls)
+    StandardLiveConnect({ globalVarName: 'liQ', appId: 'a-00xx' }, storage, calls)
     let liQ = window.liQ
     expect(liQ.ready).to.be.true()
     liQ.push({ event: 'viewProduct', name: 'a-00xx' })
@@ -129,7 +129,7 @@ describe('StandardLiveConnect', () => {
   it('should process a previously initialized liQ', function () {
     window.liQ = []
     window.liQ.push({ event: 'viewProduct', name: 'first' }, { event: 'viewProduct', name: 'second' })
-    StandardLiveConnect({ appId: 'a-00xx' }, storage, calls)
+    StandardLiveConnect({ globalVarName: 'liQ', appId: 'a-00xx' }, storage, calls)
     const liQ = window.liQ
     expect(liQ.ready).to.be.true()
     liQ.push({ event: 'viewProduct', name: 'third' })
@@ -142,7 +142,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should set the cookie', function () {
-    StandardLiveConnect({}, storage, calls)
+    StandardLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     expect(storage.getCookie('_lc2_fpi')).to.not.eql(null)
   })
 
@@ -157,7 +157,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should accept a single event and send it', function () {
-    const lc = StandardLiveConnect({}, storage, calls)
+    const lc = StandardLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     lc.push({ event: 'some' })
     expect(pixelCalls.length).to.eql(1)
     const params = urlParams(pixelCalls[0].url)
@@ -166,7 +166,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should accept an emailHash, not send an event, and then include the HEM in the next call', function () {
-    const lc = StandardLiveConnect({}, storage, calls)
+    const lc = StandardLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     lc.push({ event: 'setEmail', email: '    steve@liveIntent.com   ' })
     lc.push({ event: 'pageView' })
     expect(pixelCalls.length).to.eql(1)
@@ -178,7 +178,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('send an empty event when fired', function () {
-    const lc = StandardLiveConnect({}, storage, calls)
+    const lc = StandardLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     lc.fire()
     expect(pixelCalls.length).to.eql(1)
     const params = urlParams(pixelCalls[0].url)
@@ -187,7 +187,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should accept multiple events and send them', function () {
-    const lc = StandardLiveConnect({}, storage, calls)
+    const lc = StandardLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     lc.push({ event: 'some' }, { event: 'another' })
     expect(pixelCalls.length).to.eql(2)
     pixelCalls.forEach(call => {
@@ -197,7 +197,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should accept multiple events in an array and send them', function () {
-    const lc = StandardLiveConnect({}, storage, calls)
+    const lc = StandardLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     lc.push([{ event: 'some' }, { event: 'another' }])
     expect(pixelCalls.length).to.eql(2)
     pixelCalls.forEach(call => {
@@ -207,18 +207,18 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should return the resolution Url', function () {
-    const lc = StandardLiveConnect({}, storage, calls)
+    const lc = StandardLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     expect(lc.resolutionCallUrl()).to.match(/https:\/\/idx.liadm.com\/idex\/unknown\/any\?duid=0caaf24ab1a0--.*/)
   })
 
   it('should expose the config', function () {
-    const config = { appId: 'a-00xx' }
+    const config = { globalVarName: 'liQ', appId: 'a-00xx' }
     const lc = StandardLiveConnect(config, storage, calls)
     expect(lc.config).to.eql(config)
   })
 
   it('should emit an error if the pushed value is not an object', function () {
-    const lc = StandardLiveConnect({}, storage, calls)
+    const lc = StandardLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     lc.push([[[[[':)']]]]])
     expect(errorCalls.length).to.eql(1)
     const params = urlParams(errorCalls[0].src)
@@ -227,7 +227,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should emit an error if the pushed value is a config', function () {
-    const lc = StandardLiveConnect({}, storage, calls)
+    const lc = StandardLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     lc.push({ config: {} })
     expect(errorCalls.length).to.eql(1)
     const params = urlParams(errorCalls[0].src)
@@ -236,7 +236,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should emit an error if the storage and ajax are not provided', function () {
-    StandardLiveConnect({}, undefined, { pixelGet: calls.pixelGet })
+    StandardLiveConnect({ globalVarName: 'liQ' }, undefined, { pixelGet: calls.pixelGet })
     expect(errorCalls.length).to.eql(2)
     expect(urlParams(errorCalls[0].src).ae).to.not.be.undefined()
     expect(urlParams(errorCalls[1].src).ae).to.not.be.undefined()
@@ -258,7 +258,7 @@ describe('StandardLiveConnect', () => {
   })
 
   it('should expose the eventBus through the LC instance', function () {
-    const lc = StandardLiveConnect({}, storage, calls)
+    const lc = StandardLiveConnect({ globalVarName: 'liQ' }, storage, calls)
     expect(lc.eventBus).to.not.be.undefined()
   })
 })


### PR DESCRIPTION
https://liveintent.atlassian.net/browse/CM-714

This PR
- creates LiveConnect instances with a local event bus by default instead of the global bus
- does not attach the created LiveConnect instance to the `window` object if no globalVarName is provided instead of attaching `liQ` by default

Related PRs (both will be updated once this PR is merged):
- https://github.com/LiveIntent/Prebid.js/pull/11
- https://github.com/LiveIntent/liveconnectbuilder/pull/93

Author Todo List:

- [x] Adjust documentation (liQ is not automatically used as a fallback globalVarName when none is provided)
- [x] Add/adjust tests (if applicable)
- [x] Build in CI passes
- [x] Latest master revision is merged into the branch
- [x] Self-Review
- [x] Set `Ready For Review` status

This is the follow-up to get rid of the global state handling in LC: https://liveintent.atlassian.net/browse/CM-756
