### PR TITLE
NOISSUE - Get rid of clearIdexCache

### DIFF
--- a/src/standard-live-connect.ts
+++ b/src/standard-live-connect.ts
@@ -137,8 +137,6 @@ function standardInitialization(liveConnectConfig: LiveConnectConfig, externalSt
 
     const _push = (...args: unknown[]) => processArgs(args, pixelSender, enrichedState, eventBus)
 
-    clearIdexCache(eventBus, enrichedState.cookieDomain)
-
     return {
       push: _push,
       fire: () => _push({}),
@@ -201,31 +199,4 @@ export function StandardLiveConnect(liveConnectConfig: LiveConnectConfig, extern
   }
   // @ts-ignore
   return lc
-}
-
-// TODO: remove this in next version
-function clearIdexCache(bus: EventBus, cookieDomain: string) {
-  if (window.localStorage) {
-    try {
-      for (const key in window.localStorage) {
-        if (key.startsWith('__li_idex_cache2')) {
-          localStorage.removeItem(key)
-        }
-      }
-    } catch (e) {
-      bus.emitErrorWithMessage('ClearIdexLs', 'Failed to clear localStorage', e)
-    }
-  }
-
-  try {
-    const allCookies = window.document.cookie.split(';')
-    for (const cookie of allCookies) {
-      const key = cookie.split('=')[0].trim()
-      if (key.startsWith('__li_idex_cache2')) {
-        document.cookie = `${key}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=${cookieDomain}`
-      }
-    }
-  } catch (e) {
-    bus.emitErrorWithMessage('ClearIdexCookie', 'Failed to clear cookies', e)
-  }
 }


### PR DESCRIPTION
Get rid of obsolete cookie clean-up. Bonus: `startsWith` is not supported by older browsers and removing it will solve the issue where these browsers emit an error. 

Author Todo List:

- [x] Add/adjust tests (if applicable)
- [ ] Build in CI passes
- [x] Latest master revision is merged into the branch
- [x] Self-Review
- [x] Set `Ready For Review` status
