### PR TITLE
NOISSUE -Bump Chrome min to 47 and remove IE 11

### DIFF
--- a/test-config/wdio.browserstack.conf.mjs
+++ b/test-config/wdio.browserstack.conf.mjs
@@ -13,7 +13,7 @@ const commonBStackCapabilities = {
 // https://www.browserstack.com/automate/capabilities
 const allCapabilities = [
   { browserName: 'Chrome', browserVersion: 'latest', 'bstack:options': { ...commonBStackCapabilities, os: 'Windows', osVersion: '10' } },
-  { browserName: 'Chrome', browserVersion: '40.0', 'bstack:options': { ...commonBStackCapabilities, os: 'Windows', osVersion: '7' } },
+  { browserName: 'Chrome', browserVersion: '47.0', 'bstack:options': { ...commonBStackCapabilities, os: 'Windows', osVersion: '7' } },
   { browserName: 'firefox', browserVersion: 'latest', 'bstack:options': { ...commonBStackCapabilities, os: 'Windows', osVersion: '10' } },
   { browserName: 'firefox', browserVersion: '52.0', 'bstack:options': { ...commonBStackCapabilities, os: 'Windows', osVersion: '7' } },
   { browserName: 'IE', browserVersion: '11.0', 'bstack:options': { ...commonBStackCapabilities, os: 'Windows', osVersion: '10', seleniumVersion: '3.5.2' } },

--- a/test-config/wdio.browserstack.conf.mjs
+++ b/test-config/wdio.browserstack.conf.mjs
@@ -16,7 +16,6 @@ const allCapabilities = [
   { browserName: 'Chrome', browserVersion: '47.0', 'bstack:options': { ...commonBStackCapabilities, os: 'Windows', osVersion: '7' } },
   { browserName: 'firefox', browserVersion: 'latest', 'bstack:options': { ...commonBStackCapabilities, os: 'Windows', osVersion: '10' } },
   { browserName: 'firefox', browserVersion: '52.0', 'bstack:options': { ...commonBStackCapabilities, os: 'Windows', osVersion: '7' } },
-  { browserName: 'IE', browserVersion: '11.0', 'bstack:options': { ...commonBStackCapabilities, os: 'Windows', osVersion: '10', seleniumVersion: '3.5.2' } },
   { browserName: 'Edge', browserVersion: 'latest', 'bstack:options': { ...commonBStackCapabilities, os: 'Windows', osVersion: '10' } },
 
   { browserName: 'Safari', browserVersion: '14.1', 'bstack:options': { ...commonBStackCapabilities, os: 'OS X', osVersion: 'Big Sur' } },


### PR DESCRIPTION
Chrome < 47 tests timeout. Temporarily bumping min Chrome version to 47. We decided to get rid of IE. This PR also does this. 

Author Todo List:

- [x] Add/adjust tests (if applicable)
- [x] Build in CI passes
- [x] Latest master revision is merged into the branch
- [x] Self-Review
- [x] Set `Ready For Review` status
