### PR TITLE
NOISSUE - Send cookie domain to idres

### DIFF
--- a/src/idex.ts
+++ b/src/idex.ts
@@ -47,6 +47,7 @@ export class IdentityResolver {
     this.tuples.push(...asStringParam('did', nonNullConfig.distributorId))
     this.tuples.push(...asStringParam('gpp_s', nonNullConfig.gppString))
     this.tuples.push(...asStringParam('gpp_as', nonNullConfig.gppApplicableSections?.join(',')))
+    this.tuples.push(...asStringParam('cd', nonNullConfig.cookieDomain))
 
     this.externalIds.forEach(retrievedIdentifier => {
       this.tuples.push(...asStringParam(retrievedIdentifier.name, retrievedIdentifier.value))

--- a/src/pixel/state.ts
+++ b/src/pixel/state.ts
@@ -66,7 +66,8 @@ const paramExtractors: ((state: State) => [string, string][])[] = [
   ifDefined('referrer', referrer => asStringParam('refr', referrer)),
   ifDefined('contextElements', contextElements => asStringParam('c', contextElements)),
   ifDefined('gppString', gppString => asStringParam('gpp_s', gppString)),
-  ifDefined('gppApplicableSections', gppApplicableSections => asStringParamTransform('gpp_as', gppApplicableSections, (gppAs) => gppAs.join(',')))
+  ifDefined('gppApplicableSections', gppApplicableSections => asStringParamTransform('gpp_as', gppApplicableSections, (gppAs) => gppAs.join(','))),
+  ifDefined('cookieDomain', d => asStringParam('cd', d))
 ]
 
 export class Query {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface State extends LiveConnectConfig {
   contextElements?: string
   privacyMode?: boolean
   referrer?: string
+  cookieDomain?: string
 }
 
 export interface HemStore {

--- a/test/unit/idex/identity-resolver.spec.ts
+++ b/test/unit/idex/identity-resolver.spec.ts
@@ -61,6 +61,19 @@ describe('IdentityResolver without cache', () => {
     requestToComplete.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify(response))
   })
 
+  it('should attach the cookie domain', (done) => {
+    const response = { id: 112233 }
+    const identityResolver = new IdentityResolver({ cookieDomain: '.abc.xyz.com' }, calls)
+    const successCallback = (responseAsJson) => {
+      expect(requestToComplete.url).to.eq('https://idx.liadm.com/idex/unknown/any?cd=.abc.xyz.com')
+      expect(errors).to.be.empty()
+      expect(responseAsJson).to.be.eql(response)
+      done()
+    }
+    identityResolver.resolve(successCallback)
+    requestToComplete.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify(response))
+  })
+
   it('should attach additional params', (done) => {
     const response = { id: 112233 }
     const identityResolver = new IdentityResolver({ peopleVerifiedId: '987' }, calls)

--- a/test/unit/standard-live-connect.spec.ts
+++ b/test/unit/standard-live-connect.spec.ts
@@ -185,6 +185,15 @@ describe('StandardLiveConnect', () => {
     expect(params.e).to.eql(`${hashes.md5},${hashes.sha1},${hashes.sha256}`)
   })
 
+  it('send the cookie domain', () => {
+    storage.setCookie('_li_dcdm_c', '.example.com')
+    const lc = StandardLiveConnect({}, storage, calls)
+    lc.fire()
+    expect(pixelCalls.length).to.eql(1)
+    const params = urlParams(pixelCalls[0].url)
+    expect(params.cd).to.eql('.example.com')
+  })
+
   it('send an empty event when fired', () => {
     const lc = StandardLiveConnect({}, storage, calls)
     lc.fire()


### PR DESCRIPTION
The domain will be used for filtering on the backend. The idea is to filter out bad 1st party cookies.

Related PRs:
- https://github.com/LiveIntent/live-connect/pull/285

Author Todo List:

- [x] Add/adjust tests (if applicable)
- [x] Build in CI passes
- [x] Latest master revision is merged into the branch
- [x] Self-Review
- [x] Set `Ready For Review` status
