### PR TITLE
CM-971: Rename trackerName to trackerVersion

### DIFF
--- a/COLLECTOR_PARAMS.md
+++ b/COLLECTOR_PARAMS.md
@@ -8,8 +8,8 @@
 - contains the b64 url encoded string of the JSON that was sent via `liveConnect.push` function
 ### `duid`
 - contains the LiveConnect managed first party identifier, in the `${apexDomainHash}--${ULID}`
-### `tna`
-- contains the `config.trackerName`
+### `tv`
+- contains the `config.trackerVersion`
 ### `pu`
 - the url on which the event happened, which is populated by the `page` enricher
 ### `pu_rp`

--- a/CONFIGURATION_OPTIONS.md
+++ b/CONFIGURATION_OPTIONS.md
@@ -137,13 +137,13 @@ Example:
   identifiersToResolve:["tdid","some-fpc"]
 }
 ```
-#### `trackerName` [Optional, HasDefault]
-You might want multiple trackerNames on the page, so this can be the used to separate multiple use cases. By default, LC will use the version of this module.
+#### `trackerVersion` [Optional, HasDefault]
+You might want multiple trackerVersion on the page, so this can be the used to separate multiple use cases. By default, LC will use the version of this module.
 The default value will be taken from `package.json` if it's not set.
 Example:
 ```javascript
 {
-  trackerName:"v1.0.1"
+  trackerVersion:"v2.11.4"
 }
 ```
 

--- a/src/pixel/state.ts
+++ b/src/pixel/state.ts
@@ -25,7 +25,7 @@ const paramExtractors: ((state: State) => [string, string][])[] = [
   ifDefined('distributorId', did => asStringParam('did', did)),
   ifDefined('eventSource', source => asParamOrEmpty('se', source, (s) => base64UrlEncode(JSON.stringify(s, replacer)))),
   ifDefined('liveConnectId', fpc => asStringParam('duid', fpc)),
-  ifDefined('trackerName', tn => asStringParam('tna', tn)),
+  ifDefined('trackerVersion', v => asStringParam('tv', v)),
   state => {
     if (nonNull(state.pageUrl)) {
       const [url, isPathRemoved, blockedParams] = collectUrl(state)

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface LiveConnectConfig {
   gdprConsent?: string
   expirationDays?: number
   identifiersToResolve?: string | string[]
-  trackerName?: string
+  trackerVersion?: string
   identityResolutionConfig?: IdentityResolutionConfig
   distributorId?: string
   globalVarName?: string
@@ -58,7 +58,7 @@ export interface RetrievedIdentifier {
 export interface State extends LiveConnectConfig {
   eventSource?: object
   liveConnectId?: string
-  trackerName?: string
+  trackerVersion?: string
   pageUrl?: string
   domain?: string
   hashesFromIdentifiers?: HashedEmail[]

--- a/test/it/helpers/preambled.ts
+++ b/test/it/helpers/preambled.ts
@@ -16,7 +16,7 @@ const lc = StandardLiveConnect(
     customerSpecifics,
     {
       // @ts-expect-error
-      trackerName: LC_VERSION,
+      trackerVersion: LC_VERSION,
       contextSelectors: 'p',
       contextElementsLength: '100'
     }

--- a/test/unit/pixel/state.spec.ts
+++ b/test/unit/pixel/state.spec.ts
@@ -42,7 +42,7 @@ describe('EventComposition', () => {
       appId: '9898',
       eventSource: { eventName: 'viewContent' },
       liveConnectId: '213245',
-      trackerName: 'test tracker',
+      trackerVersion: 'test tracker',
       pageUrl: 'https://wwww.example.com?sss',
       errorDetails: { testError: 'testError' },
       retrievedIdentifiers: [{
@@ -68,7 +68,7 @@ describe('EventComposition', () => {
       'aid=9898', // appId
       'se=eyJldmVudE5hbWUiOiJ2aWV3Q29udGVudCJ9', // base64 of eventSource
       'duid=213245', // liveConnectId
-      'tna=test%20tracker', // trackerName
+      'tv=test%20tracker', // trackerVersion
       'pu=https%3A%2F%2Fwwww.example.com%3Fsss', // pageUrl
       'ae=eyJ0ZXN0RXJyb3IiOiJ0ZXN0RXJyb3IifQ', // base64 of errorDetails
       'ext_sample_cookie=sample_value', // retrievedIdentifiers
@@ -94,7 +94,7 @@ describe('EventComposition', () => {
       appId: '9898',
       eventSource: { eventName: 'viewContent' },
       liveConnectId: '213245',
-      trackerName: 'test tracker',
+      trackerVersion: 'test tracker',
       pageUrl: 'https://wwww.example.com?sss',
       errorDetails: { testError: 'testError' },
       retrievedIdentifiers: [{
@@ -120,7 +120,7 @@ describe('EventComposition', () => {
       'aid=9898', // appId
       'se=eyJldmVudE5hbWUiOiJ2aWV3Q29udGVudCJ9', // base64 of eventSource
       'duid=213245', // liveConnectId
-      'tna=test%20tracker', // trackerName
+      'tv=test%20tracker', // trackerVersion
       'pu=https%3A%2F%2Fwwww.example.com%3Fsss', // pageUrl
       'ae=eyJ0ZXN0RXJyb3IiOiJ0ZXN0RXJyb3IifQ', // base64 of errorDetails
       'ext_sample_cookie=sample_value', // retrievedIdentifiers
@@ -208,11 +208,11 @@ describe('EventComposition', () => {
   })
 
   it('should send the tracker name', () => {
-    const trackerName = 'some-name'
-    const pixelData = { trackerName }
+    const trackerVersion = 'some-name'
+    const pixelData = { trackerVersion }
     const event = new StateWrapper(pixelData)
-    expect(event.asQuery().toQueryString()).to.eql(`?tna=${trackerName}`)
-    assert.includeDeepMembers(event.asTuples(), [['tna', trackerName]])
+    expect(event.asQuery().toQueryString()).to.eql(`?tv=${trackerVersion}`)
+    assert.includeDeepMembers(event.asTuples(), [['tv', trackerVersion]])
   })
 
   it('should ignore nullable fields', () => {


### PR DESCRIPTION
The trackerName is confusing.
This field will be renamed in PixelEvent as well.

Author Todo List:

- [ ] Add/adjust tests (if applicable)
- [ ] Build in CI passes
- [ ] Latest master revision is merged into the branch
- [ ] Self-Review
- [ ] Set `Ready For Review` status
