### PR TITLE
CM-1083: Drop process env reference

### DIFF
--- a/src/initializer.ts
+++ b/src/initializer.ts
@@ -5,7 +5,7 @@ import { EventBus, InternalLiveConnect, LiveConnectConfig } from './types'
 import { LocalEventBus } from './events/event-bus'
 
 export function LiveConnect(liveConnectConfig: LiveConnectConfig, externalStorageHandler: StorageHandler, externalCallHandler: CallHandler, mode: 'minimal' | string, externalEventBus?: EventBus): InternalLiveConnect | null {
-  const minimalMode = mode === 'minimal' || process.env.LiveConnectMode === 'minimal'
+  const minimalMode = mode === 'minimal'
   const bus = externalEventBus || LocalEventBus()
   const configuration = (isObject(liveConnectConfig) && liveConnectConfig) || {}
   const initializationFunction = minimalMode ? MinimalLiveConnect : StandardLiveConnect


### PR DESCRIPTION
`process.env` is used in Prebid, it is not something we have in our build set up. 

Author Todo List:

- [ ] Add/adjust tests (if applicable)
- [x] Build in CI passes
- [x] Latest master revision is merged into the branch
- [x] Self-Review
- [x] Set `Ready For Review` status
