### PR TITLE
CM-971: consider trackerName field for backward compatibility 

### DIFF
--- a/src/pixel/state.ts
+++ b/src/pixel/state.ts
@@ -26,6 +26,8 @@ const paramExtractors: ((state: State) => [string, string][])[] = [
   ifDefined('eventSource', source => asParamOrEmpty('se', source, (s) => base64UrlEncode(JSON.stringify(s, replacer)))),
   ifDefined('liveConnectId', fpc => asStringParam('duid', fpc)),
   ifDefined('trackerVersion', v => asStringParam('tv', v)),
+  // For backward compatibility
+  // @ts-ignore
   ifDefined('trackerName', v => asStringParam('tv', v)),
   state => {
     if (nonNull(state.pageUrl)) {

--- a/src/pixel/state.ts
+++ b/src/pixel/state.ts
@@ -26,6 +26,7 @@ const paramExtractors: ((state: State) => [string, string][])[] = [
   ifDefined('eventSource', source => asParamOrEmpty('se', source, (s) => base64UrlEncode(JSON.stringify(s, replacer)))),
   ifDefined('liveConnectId', fpc => asStringParam('duid', fpc)),
   ifDefined('trackerVersion', v => asStringParam('tv', v)),
+  ifDefined('trackerName', v => asStringParam('tv', v)),
   state => {
     if (nonNull(state.pageUrl)) {
       const [url, isPathRemoved, blockedParams] = collectUrl(state)


### PR DESCRIPTION
If we receive trackerName from older LC versions or through prebid, it will be forwarded as `tv` to LP.

Author Todo List:

- [ ] Add/adjust tests (if applicable)
- [ ] Build in CI passes
- [ ] Latest master revision is merged into the branch
- [ ] Self-Review
- [ ] Set `Ready For Review` status
